### PR TITLE
Changed Cloudsat subcolumn reflectivity vertical ordering, from SFC-2…

### DIFF
--- a/src/cosp.F90
+++ b/src/cosp.F90
@@ -862,7 +862,7 @@ CONTAINS
        enddo
        ! Store output (if requested)
        if (associated(cospOUT%cloudsat_Ze_tot)) then
-          cospOUT%cloudsat_Ze_tot(ij:ik,:,:) = cloudsatDBZe(:,:,cloudsatIN%Nlevels:1:-1)
+          cospOUT%cloudsat_Ze_tot(ij:ik,:,:) = cloudsatDBZe(:,:,1:cloudsatIN%Nlevels)
        endif
     endif
 


### PR DESCRIPTION
This pull request has one small change, which reverses the vertical ordering of the Cloudsat subcolumn reflectivity (dbze94) from SFC-2-TOA to TOA-2-SFC. This results in changes to the reference dataset: 
[dswales@linux128 driver]$ python test_cosp2Imp.py data/outputs/UKMO/cosp2_output_um.ref.nc data/outputs/UKMO/cosp2_output_um.nc 
############################################################################################
Treating relative differences less than 0.0010000000% as insignificant
  dbze94:              15.33 % of values differ, relative range:  -4.10e+31 to  2.65e+31