### PR TITLE
bug fix in OPAQ variables

### DIFF
--- a/driver/src/cosp2_io.f90
+++ b/driver/src/cosp2_io.f90
@@ -568,7 +568,7 @@ contains
        if (status .ne. nf90_NoERR) print*,trim(nf90_strerror(status))    
     endif
     if (associated(cospOUT%calipso_cldtypemeanz)) then
-       ! Opaque cloud temperature
+       ! Opaque cloud altitude
        status = nf90_def_var(fileID,"clopaquemeanz",nf90_float, (/dimID(1)/),varID(101))
        if (status .ne. nf90_NoERR) print*,trim(nf90_strerror(status))
        status = nf90_put_att(fileID,varID(101),"long_name","CALIPSO Opaque Cloud Altitude")
@@ -577,7 +577,7 @@ contains
        if (status .ne. nf90_NoERR) print*,trim(nf90_strerror(status))
        status = nf90_put_att(fileID,varID(101),"standard_name", "opaque_cloud_altitude")
        if (status .ne. nf90_NoERR) print*,trim(nf90_strerror(status))           
-       ! Thin cloud temperature
+       ! Thin cloud altitude
        status = nf90_def_var(fileID,"clthinmeanz",nf90_float, (/dimID(1)/),varID(102))
        if (status .ne. nf90_NoERR) print*,trim(nf90_strerror(status))
        status = nf90_put_att(fileID,varID(102),"long_name","CALIPSO Thin Cloud Altitude")
@@ -608,7 +608,7 @@ contains
        if (status .ne. nf90_NoERR) print*,trim(nf90_strerror(status))
        status = nf90_put_att(fileID,varID(104),"standard_name", "opaque_cloud_altitude_se")
        if (status .ne. nf90_NoERR) print*,trim(nf90_strerror(status))           
-       ! Thin cloud 
+       ! Thin cloud altitude with respect to Surface Elevation
        status = nf90_def_var(fileID,"clthinmeanzse",nf90_float, (/dimID(1)/),varID(105))
        if (status .ne. nf90_NoERR) print*,trim(nf90_strerror(status))
        status = nf90_put_att(fileID,varID(105),"long_name","CALIPSO Thin Cloud Altitude with respect to SE")
@@ -617,7 +617,7 @@ contains
        if (status .ne. nf90_NoERR) print*,trim(nf90_strerror(status))
        status = nf90_put_att(fileID,varID(105),"standard_name", "thin_cloud_altitude_se")
        if (status .ne. nf90_NoERR) print*,trim(nf90_strerror(status))    
-       ! z_opaque 
+       ! z_opaque altitude with respect to Surface Elevation
        status = nf90_def_var(fileID,"clzopaquecalipsose",nf90_float, (/dimID(1)/),varID(106))
        if (status .ne. nf90_NoERR) print*,trim(nf90_strerror(status))
        status = nf90_put_att(fileID,varID(106),"long_name","CALIPSO z_opaque Altitude with respect to SE")

--- a/src/simulator/actsim/lidar_simulator.F90
+++ b/src/simulator/actsim/lidar_simulator.F90
@@ -1349,7 +1349,7 @@ contains
           cldy(:,:,k)=0._wp
        endwhere
        ! Fully attenuated layer detection at subgrid-scale:
-       where ( (x(:,:,k) .lt. S_att_opaq) .and. (x(:,:,k) .gt. 0.) .and. (x(:,:,k) .ne. undef) ) !DEBUG
+       where ( (x(:,:,k) .lt. S_att_opaq) .and. (x(:,:,k) .ge. 0.) .and. (x(:,:,k) .ne. undef) ) !DEBUG
           cldyopaq(:,:,k)=1._wp
        elsewhere
           cldyopaq(:,:,k)=0._wp
@@ -1363,7 +1363,7 @@ contains
           srok(:,:,k)=0._wp
        endwhere
        ! Number of usefull sub-columns layers for z_opaque 3D fraction:
-       where ( (x(:,:,k) .gt. 0.) .and. (x(:,:,k) .ne. undef) ) !DEBUG
+       where ( (x(:,:,k) .ge. 0.) .and. (x(:,:,k) .ne. undef) ) !DEBUG
           srokopaq(:,:,k)=1._wp
        elsewhere
           srokopaq(:,:,k)=0._wp

--- a/src/simulator/actsim/lidar_simulator.F90
+++ b/src/simulator/actsim/lidar_simulator.F90
@@ -1349,7 +1349,7 @@ contains
           cldy(:,:,k)=0._wp
        endwhere
        ! Fully attenuated layer detection at subgrid-scale:
-       where ( (x(:,:,k) .lt. S_att_opaq) .and. (x(:,:,k) .ge. 0.) .and. (x(:,:,k) .ne. undef) ) !DEBUG
+       where ( (x(:,:,k) .lt. S_att_opaq) .and. (x(:,:,k) .ge. 0.) .and. (x(:,:,k) .ne. undef) )
           cldyopaq(:,:,k)=1._wp
        elsewhere
           cldyopaq(:,:,k)=0._wp
@@ -1363,7 +1363,7 @@ contains
           srok(:,:,k)=0._wp
        endwhere
        ! Number of usefull sub-columns layers for z_opaque 3D fraction:
-       where ( (x(:,:,k) .ge. 0.) .and. (x(:,:,k) .ne. undef) ) !DEBUG
+       where ( (x(:,:,k) .ge. 0.) .and. (x(:,:,k) .ne. undef) )
           srokopaq(:,:,k)=1._wp
        elsewhere
           srokopaq(:,:,k)=0._wp


### PR DESCRIPTION
There was a bug in the COSP_OPAQ subroutine of the lidar simulator. Some opaque cloud profiles were not declared as such because the condition to define a fully attenuated lidar signal in an atmospheric layer was mistakenly excluding the 0 value. This has been corrected by changing the condition to ".ge. 0" (greater or equal than 0) instead of ".gt. 0" (greater than 0) where needed. Indeed, unlike for CALIPSO observations, the lidar simulator Scattering Ratio (SR) signal can abruptly be equal to 0 below an opaque cloud without having gone through a value greater than 0 and less than 0.06.