### PR TITLE
Fixing CloudSat Precip flag surface elevation bug

### DIFF
--- a/driver/src/cosp2_io.f90
+++ b/driver/src/cosp2_io.f90
@@ -568,7 +568,7 @@ contains
        if (status .ne. nf90_NoERR) print*,trim(nf90_strerror(status))    
     endif
     if (associated(cospOUT%calipso_cldtypemeanz)) then
-       ! Opaque cloud temperature
+       ! Opaque cloud altitude
        status = nf90_def_var(fileID,"clopaquemeanz",nf90_float, (/dimID(1)/),varID(101))
        if (status .ne. nf90_NoERR) print*,trim(nf90_strerror(status))
        status = nf90_put_att(fileID,varID(101),"long_name","CALIPSO Opaque Cloud Altitude")
@@ -577,7 +577,7 @@ contains
        if (status .ne. nf90_NoERR) print*,trim(nf90_strerror(status))
        status = nf90_put_att(fileID,varID(101),"standard_name", "opaque_cloud_altitude")
        if (status .ne. nf90_NoERR) print*,trim(nf90_strerror(status))           
-       ! Thin cloud temperature
+       ! Thin cloud altitude
        status = nf90_def_var(fileID,"clthinmeanz",nf90_float, (/dimID(1)/),varID(102))
        if (status .ne. nf90_NoERR) print*,trim(nf90_strerror(status))
        status = nf90_put_att(fileID,varID(102),"long_name","CALIPSO Thin Cloud Altitude")
@@ -608,7 +608,7 @@ contains
        if (status .ne. nf90_NoERR) print*,trim(nf90_strerror(status))
        status = nf90_put_att(fileID,varID(104),"standard_name", "opaque_cloud_altitude_se")
        if (status .ne. nf90_NoERR) print*,trim(nf90_strerror(status))           
-       ! Thin cloud 
+       ! Thin cloud altitude with respect to Surface Elevation
        status = nf90_def_var(fileID,"clthinmeanzse",nf90_float, (/dimID(1)/),varID(105))
        if (status .ne. nf90_NoERR) print*,trim(nf90_strerror(status))
        status = nf90_put_att(fileID,varID(105),"long_name","CALIPSO Thin Cloud Altitude with respect to SE")
@@ -617,7 +617,7 @@ contains
        if (status .ne. nf90_NoERR) print*,trim(nf90_strerror(status))
        status = nf90_put_att(fileID,varID(105),"standard_name", "thin_cloud_altitude_se")
        if (status .ne. nf90_NoERR) print*,trim(nf90_strerror(status))    
-       ! z_opaque 
+       ! z_opaque altitude with respect to Surface Elevation
        status = nf90_def_var(fileID,"clzopaquecalipsose",nf90_float, (/dimID(1)/),varID(106))
        if (status .ne. nf90_NoERR) print*,trim(nf90_strerror(status))
        status = nf90_put_att(fileID,varID(106),"long_name","CALIPSO z_opaque Altitude with respect to SE")

--- a/driver/src/cosp2_test.f90
+++ b/driver/src/cosp2_test.f90
@@ -45,8 +45,7 @@ program cosp2_test
                                  tau_binBoundsV1p4,tau_binEdgesV1p4, tau_binCentersV1p4,  &
                                  grLidar532_histBsct,atlid_histBsct,vgrid_zu,vgrid_zl,    & 
                                  Nlvgrid_local  => Nlvgrid,                               &
-!                                 vgrid_z_local  => vgrid_z,cloudsat_preclvl !PREC_BUG
-                                 vgrid_z_local  => vgrid_z !PREC_BUG
+                                 vgrid_z_local  => vgrid_z,cloudsat_preclvl
   use cosp_phys_constants, only: amw,amd,amO3,amCO2,amCH4,amN2O,amCO
   use mod_cosp_io,         only: nc_read_input_file,write_cosp2_output
   USE mod_quickbeam_optics,only: size_distribution,hydro_class_init,quickbeam_optics,     &
@@ -548,8 +547,9 @@ contains
     ! Local variables
     type(rng_state),allocatable,dimension(:) :: rngs  ! Seeds for random number generator
     integer,dimension(:),allocatable :: seed
-    integer,dimension(:),allocatable :: cloudsat_preclvl_index !PREC_BUG
+    integer,dimension(:),allocatable :: cloudsat_preclvl_index
     integer :: i,j,k
+    real(wp) :: zstep
     real(wp),dimension(:,:), allocatable :: &
          ls_p_rate, cv_p_rate, frac_ls, frac_cv, prec_ls, prec_cv,g_vol
     real(wp),dimension(:,:,:),  allocatable :: &
@@ -859,20 +859,20 @@ contains
        fracPrecipIce_statGrid(:,:,:) = 0._wp
        call cosp_change_vertical_grid(Npoints, Ncolumns, Nlevels, cospstateIN%hgt_matrix(:,Nlevels:1:-1), &
             cospstateIN%hgt_matrix_half(:,Nlevels:1:-1), fracPrecipIce(:,:,Nlevels:1:-1), Nlvgrid_local,  &
-!            vgrid_zl(Nlvgrid_local:1:-1),  vgrid_zu(Nlvgrid_local:1:-1), fracPrecipIce_statGrid !PREC_BUG
-            vgrid_zl(Nlvgrid_local:1:-1),  vgrid_zu(Nlvgrid_local:1:-1), fracPrecipIce_statGrid(:,:,Nlvgrid_local:1:-1)) !PREC_BUG
+            vgrid_zl(Nlvgrid_local:1:-1), vgrid_zu(Nlvgrid_local:1:-1), fracPrecipIce_statGrid(:,:,Nlvgrid_local:1:-1))
 
-       ! Find proper layer above de surface elevation to compute precip flags in Cloudsat/Calipso statistical grid     !PREC_BUG
-       allocate(cloudsat_preclvl_index(nPoints))                                            !PREC_BUG
-       cloudsat_preclvl_index(:) = 0._wp                                                    !PREC_BUG
-       ! Computing altitude index for precip flags calculation (one layer above surfelev layer)   !PREC_BUG
-       cloudsat_preclvl_index(:) = 39 - floor( cospstateIN%surfelev(:)/480. )               !PREC_BUG
+       ! Find proper layer above de surface elevation to compute precip flags in Cloudsat/Calipso statistical grid
+       allocate(cloudsat_preclvl_index(nPoints))
+       cloudsat_preclvl_index(:) = 0._wp
+       ! Compute the zstep distance between two atmopsheric layers
+       zstep = vgrid_zl(1)-vgrid_zl(2)
+       ! Computing altitude index for precip flags calculation (one layer above surfelev layer)
+       cloudsat_preclvl_index(:) = cloudsat_preclvl - floor( cospstateIN%surfelev(:)/zstep )
 
        ! For near-surface diagnostics, we only need the frozen fraction at one layer.
-!       cospIN%fracPrecipIce(:,:) = fracPrecipIce_statGrid(:,:,cloudsat_preclvl) !PREC_BUG
-        do i=1,nPoints                                                                       !PREC_BUG
-          cospIN%fracPrecipIce(i,:) = fracPrecipIce_statGrid(i,:,cloudsat_preclvl_index(i)) !PREC_BUG
-        enddo                                                                                !PREC_BUG
+        do i=1,nPoints
+          cospIN%fracPrecipIce(i,:) = fracPrecipIce_statGrid(i,:,cloudsat_preclvl_index(i))
+        enddo
 
     endif
    

--- a/driver/test_cosp2Imp.py
+++ b/driver/test_cosp2Imp.py
@@ -97,7 +97,9 @@ if (args.cmor == 'None'):
         # Compute relative difference.
         diff  = var/var_ref-1
         diff[numpy.where(var_ref == 0.0)] = 0.0
-        
+        # Relative difference = 1 if var_ref = 0 and var != var_ref
+        diff[(var_ref == 0.0) & (var != var_ref)] = 1.0
+
         # Flag any point which exceeds error threshold. 
         error = numpy.argwhere(abs(diff) >= args.zeroThresh)
         

--- a/src/cosp.F90
+++ b/src/cosp.F90
@@ -46,7 +46,8 @@ MODULE MOD_COSP
                                          ntau,modis_histTau,tau_binBounds,               &
                                          modis_histTauEdges,tau_binEdges,nCloudsatPrecipClass,&
                                          modis_histTauCenters,tau_binCenters,            &
-                                         cloudsat_preclvl,grLidar532_histBsct,atlid_histBsct                                
+!                                         cloudsat_preclvl,grLidar532_histBsct,atlid_histBsct !PREC_BUG
+                                         grLidar532_histBsct,atlid_histBsct
   USE MOD_COSP_MODIS_INTERFACE,      ONLY: cosp_modis_init,       modis_IN
   USE MOD_COSP_RTTOV_INTERFACE,      ONLY: cosp_rttov_init,       rttov_IN
   USE MOD_COSP_MISR_INTERFACE,       ONLY: cosp_misr_init,        misr_IN
@@ -1241,8 +1242,10 @@ CONTAINS
        ! Call simulator
        call quickbeam_column(cloudsatIN%Npoints, cloudsatIN%Ncolumns, cloudsatIN%Nlevels,&
             Nlvgrid, cloudsat_DBZE_BINS, 'cloudsat', cloudsatDBZe, cloudsatZe_non,       &
-            cospgridIN%land(:), cospgridIN%at(:,cospIN%Nlevels), cospIN%fracPrecipIce,   &
-            cospgridIN%hgt_matrix, cospgridIN%hgt_matrix_half,                           &
+!            cospgridIN%land(:), cospgridIN%at(:,cospIN%Nlevels), cospIN%fracPrecipIce,   & !PREC_BUG
+!            cospgridIN%hgt_matrix, cospgridIN%hgt_matrix_half,                           & !PREC_BUG
+            cospgridIN%land(:), cospgridIN%surfelev(:), cospgridIN%at(:,cospIN%Nlevels), & !PREC_BUG
+      cospIN%fracPrecipIce, cospgridIN%hgt_matrix, cospgridIN%hgt_matrix_half,     & !PREC_BUG
             cospOUT%cloudsat_cfad_ze(ij:ik,:,:), cospOUT%cloudsat_precip_cover,          &
             cospOUT%cloudsat_pia)
        ! Free up memory  (if necessary)

--- a/src/cosp.F90
+++ b/src/cosp.F90
@@ -1244,7 +1244,7 @@ CONTAINS
             cospgridIN%land(:), cospgridIN%surfelev(:), cospgridIN%at(:,cospIN%Nlevels), &
             cospIN%fracPrecipIce, cospgridIN%hgt_matrix, cospgridIN%hgt_matrix_half,     &
             cospOUT%cloudsat_cfad_ze(ij:ik,:,:), cospOUT%cloudsat_precip_cover,          &
-            cospOUT%cloudsat_pia))
+            cospOUT%cloudsat_pia)
        ! Free up memory  (if necessary)
        if (allocated(out1D_1)) then
           deallocate(out1D_1)

--- a/src/cosp.F90
+++ b/src/cosp.F90
@@ -46,8 +46,7 @@ MODULE MOD_COSP
                                          ntau,modis_histTau,tau_binBounds,               &
                                          modis_histTauEdges,tau_binEdges,nCloudsatPrecipClass,&
                                          modis_histTauCenters,tau_binCenters,            &
-!                                         cloudsat_preclvl,grLidar532_histBsct,atlid_histBsct !PREC_BUG
-                                         grLidar532_histBsct,atlid_histBsct !PREC_BUG
+                                         cloudsat_preclvl,grLidar532_histBsct,atlid_histBsct
   USE MOD_COSP_MODIS_INTERFACE,      ONLY: cosp_modis_init,       modis_IN
   USE MOD_COSP_RTTOV_INTERFACE,      ONLY: cosp_rttov_init,       rttov_IN
   USE MOD_COSP_MISR_INTERFACE,       ONLY: cosp_misr_init,        misr_IN
@@ -1242,10 +1241,8 @@ CONTAINS
        ! Call simulator
        call quickbeam_column(cloudsatIN%Npoints, cloudsatIN%Ncolumns, cloudsatIN%Nlevels,&
             Nlvgrid, cloudsat_DBZE_BINS, 'cloudsat', cloudsatDBZe, cloudsatZe_non,       &
-!            cospgridIN%land(:), cospgridIN%at(:,cospIN%Nlevels), cospIN%fracPrecipIce,   & !PREC_BUG
-!            cospgridIN%hgt_matrix, cospgridIN%hgt_matrix_half,                           & !PREC_BUG
-            cospgridIN%land(:), cospgridIN%surfelev(:), cospgridIN%at(:,cospIN%Nlevels), & !PREC_BUG
-      cospIN%fracPrecipIce, cospgridIN%hgt_matrix, cospgridIN%hgt_matrix_half,     & !PREC_BUG
+            cospgridIN%land(:), cospgridIN%surfelev(:), cospgridIN%at(:,cospIN%Nlevels), &
+            cospIN%fracPrecipIce, cospgridIN%hgt_matrix, cospgridIN%hgt_matrix_half,     &
             cospOUT%cloudsat_cfad_ze(ij:ik,:,:), cospOUT%cloudsat_precip_cover,          &
             cospOUT%cloudsat_pia)
        ! Free up memory  (if necessary)

--- a/src/cosp.F90
+++ b/src/cosp.F90
@@ -1244,7 +1244,7 @@ CONTAINS
             cospgridIN%land(:), cospgridIN%surfelev(:), cospgridIN%at(:,cospIN%Nlevels), &
             cospIN%fracPrecipIce, cospgridIN%hgt_matrix, cospgridIN%hgt_matrix_half,     &
             cospOUT%cloudsat_cfad_ze(ij:ik,:,:), cospOUT%cloudsat_precip_cover,          &
-            cospOUT%cloudsat_pia)
+            cospOUT%cloudsat_pia))
        ! Free up memory  (if necessary)
        if (allocated(out1D_1)) then
           deallocate(out1D_1)

--- a/src/cosp.F90
+++ b/src/cosp.F90
@@ -47,7 +47,7 @@ MODULE MOD_COSP
                                          modis_histTauEdges,tau_binEdges,nCloudsatPrecipClass,&
                                          modis_histTauCenters,tau_binCenters,            &
 !                                         cloudsat_preclvl,grLidar532_histBsct,atlid_histBsct !PREC_BUG
-                                         grLidar532_histBsct,atlid_histBsct
+                                         grLidar532_histBsct,atlid_histBsct !PREC_BUG
   USE MOD_COSP_MODIS_INTERFACE,      ONLY: cosp_modis_init,       modis_IN
   USE MOD_COSP_RTTOV_INTERFACE,      ONLY: cosp_rttov_init,       rttov_IN
   USE MOD_COSP_MISR_INTERFACE,       ONLY: cosp_misr_init,        misr_IN

--- a/src/cosp_config.F90
+++ b/src/cosp_config.F90
@@ -311,8 +311,8 @@ MODULE MOD_COSP_CONFIG
          Zbinvallnd = (/10._wp, 5._wp, 2.5_wp, -2.5_wp, -5._wp, -15._wp/)
     ! Vertical level index(Nlvgrid) for Cloudsat precipitation occurence/frequency diagnostics.
     ! Level 39 of Nlvgrid(40) is 480-960m.
-    integer, parameter :: &
-         cloudsat_preclvl = 39
+!    integer, parameter :: &    !PREC_BUG
+!         cloudsat_preclvl = 39 !PREC_BUG
     
     ! ####################################################################################
     ! Parameters used by the CALIPSO LIDAR simulator

--- a/src/cosp_config.F90
+++ b/src/cosp_config.F90
@@ -311,8 +311,8 @@ MODULE MOD_COSP_CONFIG
          Zbinvallnd = (/10._wp, 5._wp, 2.5_wp, -2.5_wp, -5._wp, -15._wp/)
     ! Vertical level index(Nlvgrid) for Cloudsat precipitation occurence/frequency diagnostics.
     ! Level 39 of Nlvgrid(40) is 480-960m.
-!    integer, parameter :: &    !PREC_BUG
-!         cloudsat_preclvl = 39 !PREC_BUG
+    integer, parameter :: &
+         cloudsat_preclvl = 39
     
     ! ####################################################################################
     ! Parameters used by the CALIPSO LIDAR simulator

--- a/src/simulator/actsim/lidar_simulator.F90
+++ b/src/simulator/actsim/lidar_simulator.F90
@@ -1349,7 +1349,7 @@ contains
           cldy(:,:,k)=0._wp
        endwhere
        ! Fully attenuated layer detection at subgrid-scale:
-       where ( (x(:,:,k) .lt. S_att_opaq) .and. (x(:,:,k) .gt. 0.) .and. (x(:,:,k) .ne. undef) ) !DEBUG
+       where ( (x(:,:,k) .lt. S_att_opaq) .and. (x(:,:,k) .ge. 0.) .and. (x(:,:,k) .ne. undef) ) !DEBUG
           cldyopaq(:,:,k)=1._wp
        elsewhere
           cldyopaq(:,:,k)=0._wp
@@ -1363,7 +1363,7 @@ contains
           srok(:,:,k)=0._wp
        endwhere
        ! Number of usefull sub-columns layers for z_opaque 3D fraction:
-       where ( (x(:,:,k) .gt. 0.) .and. (x(:,:,k) .ne. undef) ) !DEBUG
+       where ( (x(:,:,k) .ge. 0.) .and. (x(:,:,k) .ne. undef) ) !DEBUG
           srokopaq(:,:,k)=1._wp
        elsewhere
           srokopaq(:,:,k)=0._wp

--- a/src/simulator/actsim/lidar_simulator.F90
+++ b/src/simulator/actsim/lidar_simulator.F90
@@ -1349,7 +1349,7 @@ contains
           cldy(:,:,k)=0._wp
        endwhere
        ! Fully attenuated layer detection at subgrid-scale:
-       where ( (x(:,:,k) .lt. S_att_opaq) .and. (x(:,:,k) .ge. 0.) .and. (x(:,:,k) .ne. undef) ) !DEBUG
+       where ( (x(:,:,k) .lt. S_att_opaq) .and. (x(:,:,k) .ge. 0.) .and. (x(:,:,k) .ne. undef) )
           cldyopaq(:,:,k)=1._wp
        elsewhere
           cldyopaq(:,:,k)=0._wp
@@ -1363,7 +1363,7 @@ contains
           srok(:,:,k)=0._wp
        endwhere
        ! Number of usefull sub-columns layers for z_opaque 3D fraction:
-       where ( (x(:,:,k) .ge. 0.) .and. (x(:,:,k) .ne. undef) ) !DEBUG
+       where ( (x(:,:,k) .ge. 0.) .and. (x(:,:,k) .ne. undef) )
           srokopaq(:,:,k)=1._wp
        elsewhere
           srokopaq(:,:,k)=0._wp

--- a/src/simulator/quickbeam/quickbeam.F90
+++ b/src/simulator/quickbeam/quickbeam.F90
@@ -265,8 +265,7 @@ contains
          cloudsat_precip_cover ! Model precip rate in by CloudSat precip flag
     real(wp),dimension(Npoints),intent(out) :: &
          cloudsat_pia          ! Cloudsat path integrated attenuation
-    real(wp),dimension(nPoint,nColumns)  :: &
-        radar_preclvl
+    
     ! Local variables
     integer :: i,j
     real(wp) :: zstep
@@ -351,7 +350,7 @@ contains
   !        parameter cloudsat_preclvl, defined in src/cosp_config.F90
   ! ######################################################################################
   subroutine cloudsat_precipOccurence(Npoints, Ncolumns, llm, Nhydro, Ze_out, Ze_non_out, &
-       land, surfelev, t2m, fracPrecipIce,  cloudsat_precip_cover, cloudsat_pia, zstep, radar_preclvl)
+       land, surfelev, t2m, fracPrecipIce,  cloudsat_precip_cover, cloudsat_pia, zstep)
  
     ! Inputs
     integer,intent(in) :: &

--- a/src/simulator/quickbeam/quickbeam.F90
+++ b/src/simulator/quickbeam/quickbeam.F90
@@ -374,9 +374,7 @@ contains
     real(wp),dimension(Npoints,nCloudsatPrecipClass),intent(out) :: &
          cloudsat_precip_cover ! Model precip rate in by CloudSat precip flag
     real(wp),dimension(Npoints),intent(out) :: &
-         cloudsat_pia          ! Cloudsat path integrated attenuation
-    real(wp),dimension(Npoints,nColumns) :: &
-         radar_preclvl			        
+         cloudsat_pia          ! Cloudsat path integrated attenuation			        
 
     ! Local variables 
     integer,dimension(Npoints,Ncolumns) :: &
@@ -403,12 +401,6 @@ contains
     ! ######################################################################################
     do i=1, Npoints
        do pr=1,Ncolumns
-          j = cloudsat_preclvl
-	  do while (Ze_out(i,pr,j) .eq. R_UNDEF)
-	     j = j-1
-          enddo
-          radar_preclvl(i,pr) = j-1
-          
           ! Compute precipitation flag
           ! ################################################################################
           ! 1) Oceanic points.
@@ -416,45 +408,45 @@ contains
           if (land(i) .eq. 0) then
 
              ! 1a) Compute the PIA in all profiles containing hydrometeors
-             if ( (Ze_non_out(i,pr,radar_preclvl(i,pr)).gt.-100) .and. (Ze_out(i,pr,radar_preclvl(i,pr)).gt.-100) ) then
-                if ( (Ze_non_out(i,pr,radar_preclvl(i,pr)).lt.100) .and. (Ze_out(i,pr,radar_preclvl(i,pr)).lt.100) ) then
-                   cloudsat_precip_pia(i,pr) = Ze_non_out(i,pr,radar_preclvl(i,pr)) - Ze_out(i,pr,radar_preclvl(i,pr))
+             if ( (Ze_non_out(i,pr,cloudsat_preclvl_index(i)).gt.-100) .and. (Ze_out(i,pr,cloudsat_preclvl_index(i)).gt.-100) ) then
+                if ( (Ze_non_out(i,pr,cloudsat_preclvl_index(i)).lt.100) .and. (Ze_out(i,pr,cloudsat_preclvl_index(i)).lt.100) ) then
+                   cloudsat_precip_pia(i,pr) = Ze_non_out(i,pr,cloudsat_preclvl_index(i)) - Ze_out(i,pr,cloudsat_preclvl_index(i))
                 endif
              endif
 
              ! Snow
              if(fracPrecipIce(i,pr).gt.0.9) then
-                if(Ze_non_out(i,pr,radar_preclvl(i,pr)).gt.Zenonbinval(2)) then
+                if(Ze_non_out(i,pr,cloudsat_preclvl_index(i)).gt.Zenonbinval(2)) then
                    cloudsat_pflag(i,pr) = pClass_Snow2                   ! TSL: Snow certain
                 endif
-                if(Ze_non_out(i,pr,radar_preclvl(i,pr)).gt.Zenonbinval(4).and. &
-                     Ze_non_out(i,pr,radar_preclvl(i,pr)).le.Zenonbinval(2)) then
+                if(Ze_non_out(i,pr,cloudsat_preclvl_index(i)).gt.Zenonbinval(4).and. &
+                     Ze_non_out(i,pr,cloudsat_preclvl_index(i)).le.Zenonbinval(2)) then
                    cloudsat_pflag(i,pr) = pClass_Snow1                   ! TSL: Snow possible
                 endif
              endif
              
              ! Mixed
              if(fracPrecipIce(i,pr).gt.0.1.and.fracPrecipIce(i,pr).le.0.9) then
-                if(Ze_non_out(i,pr,radar_preclvl(i,pr)).gt.Zenonbinval(2)) then
+                if(Ze_non_out(i,pr,cloudsat_preclvl_index(i)).gt.Zenonbinval(2)) then
                    cloudsat_pflag(i,pr) = pClass_Mixed2                  ! TSL: Mixed certain
                 endif
-                if(Ze_non_out(i,pr,radar_preclvl(i,pr)).gt.Zenonbinval(4).and. &
-                     Ze_non_out(i,pr,radar_preclvl(i,pr)).le.Zenonbinval(2)) then
+                if(Ze_non_out(i,pr,cloudsat_preclvl_index(i)).gt.Zenonbinval(4).and. &
+                     Ze_non_out(i,pr,cloudsat_preclvl_index(i)).le.Zenonbinval(2)) then
                    cloudsat_pflag(i,pr) = pClass_Mixed1                  ! TSL: Mixed possible
                 endif
              endif
              
              ! Rain
              if(fracPrecipIce(i,pr).le.0.1) then
-                if(Ze_non_out(i,pr,radar_preclvl(i,pr)).gt.Zenonbinval(1)) then
+                if(Ze_non_out(i,pr,cloudsat_preclvl_index(i)).gt.Zenonbinval(1)) then
                    cloudsat_pflag(i,pr) = pClass_Rain3                   ! TSL: Rain certain
                 endif
-                if(Ze_non_out(i,pr,radar_preclvl(i,pr)).gt.Zenonbinval(3).and. &
-                     Ze_non_out(i,pr,radar_preclvl(i,pr)).le.Zenonbinval(1)) then
+                if(Ze_non_out(i,pr,cloudsat_preclvl_index(i)).gt.Zenonbinval(3).and. &
+                     Ze_non_out(i,pr,cloudsat_preclvl_index(i)).le.Zenonbinval(1)) then
                    cloudsat_pflag(i,pr) = pClass_Rain2                   ! TSL: Rain probable
                 endif
-                if(Ze_non_out(i,pr,radar_preclvl(i,pr)).gt.Zenonbinval(4).and. &
-                     Ze_non_out(i,pr,radar_preclvl(i,pr)).le.Zenonbinval(3)) then
+                if(Ze_non_out(i,pr,cloudsat_preclvl_index(i)).gt.Zenonbinval(4).and. &
+                     Ze_non_out(i,pr,cloudsat_preclvl_index(i)).le.Zenonbinval(3)) then
                    cloudsat_pflag(i,pr) = pClass_Rain1                   ! TSL: Rain possible
                 endif
                 if(cloudsat_precip_pia(i,pr).gt.40) then
@@ -463,7 +455,7 @@ contains
              endif
              
              ! No precipitation
-             if(Ze_non_out(i,pr,radar_preclvl(i,pr)).le.-15) then
+             if(Ze_non_out(i,pr,cloudsat_preclvl_index(i)).le.-15) then
                 cloudsat_pflag(i,pr) = pClass_noPrecip                   ! TSL: Not Raining
              endif
           endif ! Ocean points
@@ -473,9 +465,9 @@ contains
           ! ################################################################################
           if (land(i) .eq. 1) then
              ! 2a) Compute the PIA in all profiles containing hydrometeors
-             if ( (Ze_non_out(i,pr,radar_preclvl(i,pr)-1).gt.-100) .and. (Ze_out(i,pr,radar_preclvl(i,pr)-1).gt.-100) ) then
-                if ( (Ze_non_out(i,pr,radar_preclvl(i,pr)-1).lt.100) .and. (Ze_out(i,pr,radar_preclvl(i,pr)-1).lt.100) ) then
-                   cloudsat_precip_pia(i,pr) = Ze_non_out(i,pr,radar_preclvl(i,pr)-1) - Ze_out(i,pr,radar_preclvl(i,pr)-1)
+             if ( (Ze_non_out(i,pr,cloudsat_preclvl_index(i)-1).gt.-100) .and. (Ze_out(i,pr,cloudsat_preclvl_index(i)-1).gt.-100) ) then
+                if ( (Ze_non_out(i,pr,cloudsat_preclvl_index(i)-1).lt.100) .and. (Ze_out(i,pr,cloudsat_preclvl_index(i)-1).lt.100) ) then
+                   cloudsat_precip_pia(i,pr) = Ze_non_out(i,pr,cloudsat_preclvl_index(i)-1) - Ze_out(i,pr,cloudsat_preclvl_index(i)-1)
                 endif
              endif
 
@@ -484,11 +476,11 @@ contains
 
              ! Snow (T<273)
              if(t2m(i) .lt. 273._wp) then
-                if(Ze_out(i,pr,radar_preclvl(i,pr)-1) .gt. Zbinvallnd(5)) then
+                if(Ze_out(i,pr,cloudsat_preclvl_index(i)-1) .gt. Zbinvallnd(5)) then
                    cloudsat_pflag(i,pr) = pClass_Snow2                      ! JEK: Snow certain
                 endif
-                if(Ze_out(i,pr,radar_preclvl(i,pr)-1) .gt. Zbinvallnd(6) .and. &
-                     Ze_out(i,pr,radar_preclvl(i,pr)-1).le.Zbinvallnd(5)) then
+                if(Ze_out(i,pr,cloudsat_preclvl_index(i)-1) .gt. Zbinvallnd(6) .and. &
+                     Ze_out(i,pr,cloudsat_preclvl_index(i)-1).le.Zbinvallnd(5)) then
                    cloudsat_pflag(i,pr) = pClass_Snow1                      ! JEK: Snow possible
                 endif
              endif
@@ -496,11 +488,11 @@ contains
              ! Mized phase (273<T<275)
              if(t2m(i) .ge. 273._wp .and. t2m(i) .le. 275._wp) then
                 if ((Zmax .gt. Zbinvallnd(1) .and. cloudsat_precip_pia(i,pr).gt.30) .or. &
-                     (Ze_out(i,pr,radar_preclvl(i,pr)-1) .gt. Zbinvallnd(4))) then
+                     (Ze_out(i,pr,cloudsat_preclvl_index(i)-1) .gt. Zbinvallnd(4))) then
                    cloudsat_pflag(i,pr) = pClass_Mixed2                     ! JEK: Mixed certain
                 endif
-                if ((Ze_out(i,pr,radar_preclvl(i,pr)-1) .gt. Zbinvallnd(6)  .and. &
-                     Ze_out(i,pr,radar_preclvl(i,pr)-1) .le. Zbinvallnd(4)) .and. &
+                if ((Ze_out(i,pr,cloudsat_preclvl_index(i)-1) .gt. Zbinvallnd(6)  .and. &
+                     Ze_out(i,pr,cloudsat_preclvl_index(i)-1) .le. Zbinvallnd(4)) .and. &
                      (Zmax .gt. Zbinvallnd(5)) ) then
                    cloudsat_pflag(i,pr) = pClass_Mixed1                     ! JEK: Mixed possible
                 endif
@@ -509,14 +501,14 @@ contains
              ! Rain (T>275)
              if(t2m(i) .gt. 275) then
                 if ((Zmax .gt. Zbinvallnd(1) .and. cloudsat_precip_pia(i,pr).gt.30) .or. &
-                     (Ze_out(i,pr,radar_preclvl(i,pr)-1) .gt. Zbinvallnd(2))) then
+                     (Ze_out(i,pr,cloudsat_preclvl_index(i)-1) .gt. Zbinvallnd(2))) then
                    cloudsat_pflag(i,pr) = pClass_Rain3                      ! JEK: Rain certain
                 endif
-                if((Ze_out(i,pr,radar_preclvl(i,pr)-1) .gt. Zbinvallnd(6)) .and. &
+                if((Ze_out(i,pr,cloudsat_preclvl_index(i)-1) .gt. Zbinvallnd(6)) .and. &
                      (Zmax .gt. Zbinvallnd(3))) then
                    cloudsat_pflag(i,pr) = pClass_Rain2                      ! JEK: Rain probable
                 endif
-                if((Ze_out(i,pr,radar_preclvl(i,pr)-1) .gt. Zbinvallnd(6)) .and. &
+                if((Ze_out(i,pr,cloudsat_preclvl_index(i)-1) .gt. Zbinvallnd(6)) .and. &
                      (Zmax.lt.Zbinvallnd(3))) then
                    cloudsat_pflag(i,pr) = pClass_Rain1                      ! JEK: Rain possible
                 endif
@@ -526,13 +518,11 @@ contains
              endif
              
              ! No precipitation
-             if(Ze_out(i,pr,radar_preclvl(i,pr)-1) .le. -15 .and. Ze_out(i,pr,radar_preclvl(i,pr)-1) .gt. -100) then
+             if(Ze_out(i,pr,cloudsat_preclvl_index(i)-1) .le. -15 .and. Ze_out(i,pr,cloudsat_preclvl_index(i)-1) .gt. -100) then
                 cloudsat_pflag(i,pr) =  pClass_noPrecip                     ! JEK: Not Precipitating
              endif         
           endif ! Land points
        enddo ! Sub-columns
-       cloudsat_precip_pia(i,:) = radar_preclvl(i,:)
-
     enddo    ! Gridpoints
 
     ! ######################################################################################
@@ -557,9 +547,6 @@ contains
          cloudsat_precip_cover = cloudsat_precip_cover / Ncolumns
     where ((cloudsat_pia/= R_UNDEF).and.(cloudsat_pia/= 0.0)) &
          cloudsat_pia = cloudsat_pia / Ncolumns 
-
-    cloudsat_precip_cover(:,8) = radar_preclvl(:,1)
-    cloudsat_pia = surfelev
 
   end subroutine cloudsat_precipOccurence
   

--- a/src/simulator/quickbeam/quickbeam.F90
+++ b/src/simulator/quickbeam/quickbeam.F90
@@ -462,9 +462,11 @@ contains
           
           ! ################################################################################
           ! 2) Land points.
+	  !    *NOTE* For land points we go up a layer higher, so cloudsat_preclvl_index(i)-1
+	  !                  
           ! ################################################################################
-          if (land(i) .eq. 1) then
-             ! 2a) Compute the PIA in all profiles containing hydrometeors
+          if (land(i) .eq. 1) then             
+	     ! 2a) Compute the PIA in all profiles containing hydrometeors
              if ( (Ze_non_out(i,pr,cloudsat_preclvl_index(i)-1).gt.-100) .and. (Ze_out(i,pr,cloudsat_preclvl_index(i)-1).gt.-100) ) then
                 if ( (Ze_non_out(i,pr,cloudsat_preclvl_index(i)-1).lt.100) .and. (Ze_out(i,pr,cloudsat_preclvl_index(i)-1).lt.100) ) then
                    cloudsat_precip_pia(i,pr) = Ze_non_out(i,pr,cloudsat_preclvl_index(i)-1) - Ze_out(i,pr,cloudsat_preclvl_index(i)-1)

--- a/src/simulator/quickbeam/quickbeam.F90
+++ b/src/simulator/quickbeam/quickbeam.F90
@@ -407,19 +407,20 @@ contains
 	     j = j-1
           enddo
           radar_preclvl = j-1
-
-          ! 1) Compute the PIA in all profiles containing hydrometeors
-          if ( (Ze_non_out(i,pr,radar_preclvl).gt.-100) .and. (Ze_out(i,pr,radar_preclvl).gt.-100) ) then
-             if ( (Ze_non_out(i,pr,radar_preclvl).lt.100) .and. (Ze_out(i,pr,radar_preclvl).lt.100) ) then
-                cloudsat_precip_pia(i,pr) = Ze_non_out(i,pr,radar_preclvl) - Ze_out(i,pr,radar_preclvl)
-             endif
-          endif
           
-          ! 2) Compute precipitation flag
+          ! Compute precipitation flag
           ! ################################################################################
-          ! 2a) Oceanic points.
+          ! 1) Oceanic points.
           ! ################################################################################
           if (land(i) .eq. 0) then
+
+             ! 1a) Compute the PIA in all profiles containing hydrometeors
+             if ( (Ze_non_out(i,pr,radar_preclvl).gt.-100) .and. (Ze_out(i,pr,radar_preclvl).gt.-100) ) then
+                if ( (Ze_non_out(i,pr,radar_preclvl).lt.100) .and. (Ze_out(i,pr,radar_preclvl).lt.100) ) then
+                   cloudsat_precip_pia(i,pr) = Ze_non_out(i,pr,radar_preclvl) - Ze_out(i,pr,radar_preclvl)
+                endif
+             endif
+
              ! Snow
              if(fracPrecipIce(i,pr).gt.0.9) then
                 if(Ze_non_out(i,pr,radar_preclvl).gt.Zenonbinval(2)) then
@@ -467,9 +468,16 @@ contains
           endif ! Ocean points
           
           ! ################################################################################
-          ! 2b) Land points.
+          ! 2) Land points.
           ! ################################################################################
           if (land(i) .eq. 1) then
+             ! 2a) Compute the PIA in all profiles containing hydrometeors
+             if ( (Ze_non_out(i,pr,radar_preclvl-1).gt.-100) .and. (Ze_out(i,pr,radar_preclvl-1).gt.-100) ) then
+                if ( (Ze_non_out(i,pr,radar_preclvl-1).lt.100) .and. (Ze_out(i,pr,radar_preclvl-1).lt.100) ) then
+                   cloudsat_precip_pia(i,pr) = Ze_non_out(i,pr,radar_preclvl-1) - Ze_out(i,pr,radar_preclvl-1)
+                endif
+             endif
+
              ! Find Zmax, the maximum reflectivity value in the attenuated profile (Ze_out);
              Zmax=maxval(Ze_out(i,pr,:))
 

--- a/src/simulator/quickbeam/quickbeam.F90
+++ b/src/simulator/quickbeam/quickbeam.F90
@@ -469,11 +469,11 @@ contains
 
              ! Snow (T<273)
              if(t2m(i) .lt. 273._wp) then
-                if(Ze_out(i,pr,cloudsat_preclvl_index(i)) .gt. Zbinvallnd(5)) then
+                if(Ze_out(i,pr,cloudsat_preclvl_index(i)-1) .gt. Zbinvallnd(5)) then
                    cloudsat_pflag(i,pr) = pClass_Snow2                      ! JEK: Snow certain
                 endif
-                if(Ze_out(i,pr,cloudsat_preclvl_index(i)) .gt. Zbinvallnd(6) .and. &
-                     Ze_out(i,pr,cloudsat_preclvl_index(i)).le.Zbinvallnd(5)) then
+                if(Ze_out(i,pr,cloudsat_preclvl_index(i)-1) .gt. Zbinvallnd(6) .and. &
+                     Ze_out(i,pr,cloudsat_preclvl_index(i)-1).le.Zbinvallnd(5)) then
                    cloudsat_pflag(i,pr) = pClass_Snow1                      ! JEK: Snow possible
                 endif
              endif
@@ -481,11 +481,11 @@ contains
              ! Mized phase (273<T<275)
              if(t2m(i) .ge. 273._wp .and. t2m(i) .le. 275._wp) then
                 if ((Zmax .gt. Zbinvallnd(1) .and. cloudsat_precip_pia(i,pr).gt.30) .or. &
-                     (Ze_out(i,pr,cloudsat_preclvl_index(i)) .gt. Zbinvallnd(4))) then
+                     (Ze_out(i,pr,cloudsat_preclvl_index(i)-1) .gt. Zbinvallnd(4))) then
                    cloudsat_pflag(i,pr) = pClass_Mixed2                     ! JEK: Mixed certain
                 endif
-                if ((Ze_out(i,pr,cloudsat_preclvl_index(i)) .gt. Zbinvallnd(6)  .and. &
-                     Ze_out(i,pr,cloudsat_preclvl_index(i)) .le. Zbinvallnd(4)) .and. &
+                if ((Ze_out(i,pr,cloudsat_preclvl_index(i)-1) .gt. Zbinvallnd(6)  .and. &
+                     Ze_out(i,pr,cloudsat_preclvl_index(i)-1) .le. Zbinvallnd(4)) .and. &
                      (Zmax .gt. Zbinvallnd(5)) ) then
                    cloudsat_pflag(i,pr) = pClass_Mixed1                     ! JEK: Mixed possible
                 endif
@@ -494,14 +494,14 @@ contains
              ! Rain (T>275)
              if(t2m(i) .gt. 275) then
                 if ((Zmax .gt. Zbinvallnd(1) .and. cloudsat_precip_pia(i,pr).gt.30) .or. &
-                     (Ze_out(i,pr,cloudsat_preclvl_index(i)) .gt. Zbinvallnd(2))) then
+                     (Ze_out(i,pr,cloudsat_preclvl_index(i)-1) .gt. Zbinvallnd(2))) then
                    cloudsat_pflag(i,pr) = pClass_Rain3                      ! JEK: Rain certain
                 endif
-                if((Ze_out(i,pr,cloudsat_preclvl_index(i)) .gt. Zbinvallnd(6)) .and. &
+                if((Ze_out(i,pr,cloudsat_preclvl_index(i)-1) .gt. Zbinvallnd(6)) .and. &
                      (Zmax .gt. Zbinvallnd(3))) then
                    cloudsat_pflag(i,pr) = pClass_Rain2                      ! JEK: Rain probable
                 endif
-                if((Ze_out(i,pr,cloudsat_preclvl_index(i)) .gt. Zbinvallnd(6)) .and. &
+                if((Ze_out(i,pr,cloudsat_preclvl_index(i)-1) .gt. Zbinvallnd(6)) .and. &
                      (Zmax.lt.Zbinvallnd(3))) then
                    cloudsat_pflag(i,pr) = pClass_Rain1                      ! JEK: Rain possible
                 endif
@@ -511,7 +511,7 @@ contains
              endif
              
              ! No precipitation
-             if(Ze_out(i,pr,cloudsat_preclvl_index(i)).le.-15) then
+             if(Ze_out(i,pr,cloudsat_preclvl_index(i)-1).le.-15) then
                 cloudsat_pflag(i,pr) =  pClass_noPrecip                     ! JEK: Not Precipitating
              endif         
           endif ! Land points

--- a/src/simulator/quickbeam/quickbeam.F90
+++ b/src/simulator/quickbeam/quickbeam.F90
@@ -525,7 +525,7 @@ contains
              endif
              
              ! No precipitation
-             if(Ze_out(i,pr,radar_preclvl-1).le.-15) then
+             if(Ze_out(i,pr,radar_preclvl-1) .le. -15 .and. Ze_out(i,pr,radar_preclvl-1) .gt. -100) then
                 cloudsat_pflag(i,pr) =  pClass_noPrecip                     ! JEK: Not Precipitating
              endif         
           endif ! Land points

--- a/src/simulator/quickbeam/quickbeam.F90
+++ b/src/simulator/quickbeam/quickbeam.F90
@@ -403,7 +403,7 @@ contains
     ! ######################################################################################
     do i=1, Npoints
        do pr=1,Ncolumns
-          j = 40
+          j = cloudsat_preclvl
 	  do while (Ze_out(i,pr,j) .eq. R_UNDEF)
 	     j = j-1
           enddo

--- a/src/simulator/quickbeam/quickbeam.F90
+++ b/src/simulator/quickbeam/quickbeam.F90
@@ -265,7 +265,8 @@ contains
          cloudsat_precip_cover ! Model precip rate in by CloudSat precip flag
     real(wp),dimension(Npoints),intent(out) :: &
          cloudsat_pia          ! Cloudsat path integrated attenuation
-    
+    real(wp),dimension(nPoint,nColumns)  :: &
+        radar_preclvl
     ! Local variables
     integer :: i,j
     real(wp) :: zstep
@@ -350,7 +351,7 @@ contains
   !        parameter cloudsat_preclvl, defined in src/cosp_config.F90
   ! ######################################################################################
   subroutine cloudsat_precipOccurence(Npoints, Ncolumns, llm, Nhydro, Ze_out, Ze_non_out, &
-       land, surfelev, t2m, fracPrecipIce,  cloudsat_precip_cover, cloudsat_pia, zstep)
+       land, surfelev, t2m, fracPrecipIce,  cloudsat_precip_cover, cloudsat_pia, zstep, radar_preclvl)
  
     ! Inputs
     integer,intent(in) :: &
@@ -375,7 +376,9 @@ contains
          cloudsat_precip_cover ! Model precip rate in by CloudSat precip flag
     real(wp),dimension(Npoints),intent(out) :: &
          cloudsat_pia          ! Cloudsat path integrated attenuation
-    
+    real(wp),dimension(Npoints,nColumns) :: &
+         radar_preclvl			        
+
     ! Local variables 
     integer,dimension(Npoints,Ncolumns) :: &
          cloudsat_pflag,      & ! Subcolumn precipitation flag
@@ -383,7 +386,7 @@ contains
     integer,dimension(Npoints) :: &
          cloudsat_preclvl_index ! Altitude index for precip flags calculation
                                 ! in 40-level grid (one layer above surfelev) 
-    integer :: pr,i,k,m,j,radar_preclvl
+    integer :: pr,i,k,m,j
     real(wp) :: Zmax
     
     ! Initialize 
@@ -400,13 +403,12 @@ contains
     ! SUBCOLUMN processing
     ! ######################################################################################
     do i=1, Npoints
-
        do pr=1,Ncolumns
           j = 40
 	  do while (Ze_out(i,pr,j) .eq. R_UNDEF)
 	     j = j-1
           enddo
-          radar_preclvl = j-1
+          radar_preclvl(i,pr) = j-1
           
           ! Compute precipitation flag
           ! ################################################################################
@@ -415,45 +417,45 @@ contains
           if (land(i) .eq. 0) then
 
              ! 1a) Compute the PIA in all profiles containing hydrometeors
-             if ( (Ze_non_out(i,pr,radar_preclvl).gt.-100) .and. (Ze_out(i,pr,radar_preclvl).gt.-100) ) then
-                if ( (Ze_non_out(i,pr,radar_preclvl).lt.100) .and. (Ze_out(i,pr,radar_preclvl).lt.100) ) then
-                   cloudsat_precip_pia(i,pr) = Ze_non_out(i,pr,radar_preclvl) - Ze_out(i,pr,radar_preclvl)
+             if ( (Ze_non_out(i,pr,radar_preclvl(i,pr)).gt.-100) .and. (Ze_out(i,pr,radar_preclvl(i,pr)).gt.-100) ) then
+                if ( (Ze_non_out(i,pr,radar_preclvl(i,pr)).lt.100) .and. (Ze_out(i,pr,radar_preclvl(i,pr)).lt.100) ) then
+                   cloudsat_precip_pia(i,pr) = Ze_non_out(i,pr,radar_preclvl(i,pr)) - Ze_out(i,pr,radar_preclvl(i,pr))
                 endif
              endif
 
              ! Snow
              if(fracPrecipIce(i,pr).gt.0.9) then
-                if(Ze_non_out(i,pr,radar_preclvl).gt.Zenonbinval(2)) then
+                if(Ze_non_out(i,pr,radar_preclvl(i,pr)).gt.Zenonbinval(2)) then
                    cloudsat_pflag(i,pr) = pClass_Snow2                   ! TSL: Snow certain
                 endif
-                if(Ze_non_out(i,pr,radar_preclvl).gt.Zenonbinval(4).and. &
-                     Ze_non_out(i,pr,radar_preclvl).le.Zenonbinval(2)) then
+                if(Ze_non_out(i,pr,radar_preclvl(i,pr)).gt.Zenonbinval(4).and. &
+                     Ze_non_out(i,pr,radar_preclvl(i,pr)).le.Zenonbinval(2)) then
                    cloudsat_pflag(i,pr) = pClass_Snow1                   ! TSL: Snow possible
                 endif
              endif
              
              ! Mixed
              if(fracPrecipIce(i,pr).gt.0.1.and.fracPrecipIce(i,pr).le.0.9) then
-                if(Ze_non_out(i,pr,radar_preclvl).gt.Zenonbinval(2)) then
+                if(Ze_non_out(i,pr,radar_preclvl(i,pr)).gt.Zenonbinval(2)) then
                    cloudsat_pflag(i,pr) = pClass_Mixed2                  ! TSL: Mixed certain
                 endif
-                if(Ze_non_out(i,pr,radar_preclvl).gt.Zenonbinval(4).and. &
-                     Ze_non_out(i,pr,radar_preclvl).le.Zenonbinval(2)) then
+                if(Ze_non_out(i,pr,radar_preclvl(i,pr)).gt.Zenonbinval(4).and. &
+                     Ze_non_out(i,pr,radar_preclvl(i,pr)).le.Zenonbinval(2)) then
                    cloudsat_pflag(i,pr) = pClass_Mixed1                  ! TSL: Mixed possible
                 endif
              endif
              
              ! Rain
              if(fracPrecipIce(i,pr).le.0.1) then
-                if(Ze_non_out(i,pr,radar_preclvl).gt.Zenonbinval(1)) then
+                if(Ze_non_out(i,pr,radar_preclvl(i,pr)).gt.Zenonbinval(1)) then
                    cloudsat_pflag(i,pr) = pClass_Rain3                   ! TSL: Rain certain
                 endif
-                if(Ze_non_out(i,pr,radar_preclvl).gt.Zenonbinval(3).and. &
-                     Ze_non_out(i,pr,radar_preclvl).le.Zenonbinval(1)) then
+                if(Ze_non_out(i,pr,radar_preclvl(i,pr)).gt.Zenonbinval(3).and. &
+                     Ze_non_out(i,pr,radar_preclvl(i,pr)).le.Zenonbinval(1)) then
                    cloudsat_pflag(i,pr) = pClass_Rain2                   ! TSL: Rain probable
                 endif
-                if(Ze_non_out(i,pr,radar_preclvl).gt.Zenonbinval(4).and. &
-                     Ze_non_out(i,pr,radar_preclvl).le.Zenonbinval(3)) then
+                if(Ze_non_out(i,pr,radar_preclvl(i,pr)).gt.Zenonbinval(4).and. &
+                     Ze_non_out(i,pr,radar_preclvl(i,pr)).le.Zenonbinval(3)) then
                    cloudsat_pflag(i,pr) = pClass_Rain1                   ! TSL: Rain possible
                 endif
                 if(cloudsat_precip_pia(i,pr).gt.40) then
@@ -462,7 +464,7 @@ contains
              endif
              
              ! No precipitation
-             if(Ze_non_out(i,pr,radar_preclvl).le.-15) then
+             if(Ze_non_out(i,pr,radar_preclvl(i,pr)).le.-15) then
                 cloudsat_pflag(i,pr) = pClass_noPrecip                   ! TSL: Not Raining
              endif
           endif ! Ocean points
@@ -472,9 +474,9 @@ contains
           ! ################################################################################
           if (land(i) .eq. 1) then
              ! 2a) Compute the PIA in all profiles containing hydrometeors
-             if ( (Ze_non_out(i,pr,radar_preclvl-1).gt.-100) .and. (Ze_out(i,pr,radar_preclvl-1).gt.-100) ) then
-                if ( (Ze_non_out(i,pr,radar_preclvl-1).lt.100) .and. (Ze_out(i,pr,radar_preclvl-1).lt.100) ) then
-                   cloudsat_precip_pia(i,pr) = Ze_non_out(i,pr,radar_preclvl-1) - Ze_out(i,pr,radar_preclvl-1)
+             if ( (Ze_non_out(i,pr,radar_preclvl(i,pr)-1).gt.-100) .and. (Ze_out(i,pr,radar_preclvl(i,pr)-1).gt.-100) ) then
+                if ( (Ze_non_out(i,pr,radar_preclvl(i,pr)-1).lt.100) .and. (Ze_out(i,pr,radar_preclvl(i,pr)-1).lt.100) ) then
+                   cloudsat_precip_pia(i,pr) = Ze_non_out(i,pr,radar_preclvl(i,pr)-1) - Ze_out(i,pr,radar_preclvl(i,pr)-1)
                 endif
              endif
 
@@ -483,11 +485,11 @@ contains
 
              ! Snow (T<273)
              if(t2m(i) .lt. 273._wp) then
-                if(Ze_out(i,pr,radar_preclvl-1) .gt. Zbinvallnd(5)) then
+                if(Ze_out(i,pr,radar_preclvl(i,pr)-1) .gt. Zbinvallnd(5)) then
                    cloudsat_pflag(i,pr) = pClass_Snow2                      ! JEK: Snow certain
                 endif
-                if(Ze_out(i,pr,radar_preclvl-1) .gt. Zbinvallnd(6) .and. &
-                     Ze_out(i,pr,radar_preclvl-1).le.Zbinvallnd(5)) then
+                if(Ze_out(i,pr,radar_preclvl(i,pr)-1) .gt. Zbinvallnd(6) .and. &
+                     Ze_out(i,pr,radar_preclvl(i,pr)-1).le.Zbinvallnd(5)) then
                    cloudsat_pflag(i,pr) = pClass_Snow1                      ! JEK: Snow possible
                 endif
              endif
@@ -495,11 +497,11 @@ contains
              ! Mized phase (273<T<275)
              if(t2m(i) .ge. 273._wp .and. t2m(i) .le. 275._wp) then
                 if ((Zmax .gt. Zbinvallnd(1) .and. cloudsat_precip_pia(i,pr).gt.30) .or. &
-                     (Ze_out(i,pr,radar_preclvl-1) .gt. Zbinvallnd(4))) then
+                     (Ze_out(i,pr,radar_preclvl(i,pr)-1) .gt. Zbinvallnd(4))) then
                    cloudsat_pflag(i,pr) = pClass_Mixed2                     ! JEK: Mixed certain
                 endif
-                if ((Ze_out(i,pr,radar_preclvl-1) .gt. Zbinvallnd(6)  .and. &
-                     Ze_out(i,pr,radar_preclvl-1) .le. Zbinvallnd(4)) .and. &
+                if ((Ze_out(i,pr,radar_preclvl(i,pr)-1) .gt. Zbinvallnd(6)  .and. &
+                     Ze_out(i,pr,radar_preclvl(i,pr)-1) .le. Zbinvallnd(4)) .and. &
                      (Zmax .gt. Zbinvallnd(5)) ) then
                    cloudsat_pflag(i,pr) = pClass_Mixed1                     ! JEK: Mixed possible
                 endif
@@ -508,14 +510,14 @@ contains
              ! Rain (T>275)
              if(t2m(i) .gt. 275) then
                 if ((Zmax .gt. Zbinvallnd(1) .and. cloudsat_precip_pia(i,pr).gt.30) .or. &
-                     (Ze_out(i,pr,radar_preclvl-1) .gt. Zbinvallnd(2))) then
+                     (Ze_out(i,pr,radar_preclvl(i,pr)-1) .gt. Zbinvallnd(2))) then
                    cloudsat_pflag(i,pr) = pClass_Rain3                      ! JEK: Rain certain
                 endif
-                if((Ze_out(i,pr,radar_preclvl-1) .gt. Zbinvallnd(6)) .and. &
+                if((Ze_out(i,pr,radar_preclvl(i,pr)-1) .gt. Zbinvallnd(6)) .and. &
                      (Zmax .gt. Zbinvallnd(3))) then
                    cloudsat_pflag(i,pr) = pClass_Rain2                      ! JEK: Rain probable
                 endif
-                if((Ze_out(i,pr,radar_preclvl-1) .gt. Zbinvallnd(6)) .and. &
+                if((Ze_out(i,pr,radar_preclvl(i,pr)-1) .gt. Zbinvallnd(6)) .and. &
                      (Zmax.lt.Zbinvallnd(3))) then
                    cloudsat_pflag(i,pr) = pClass_Rain1                      ! JEK: Rain possible
                 endif
@@ -525,11 +527,13 @@ contains
              endif
              
              ! No precipitation
-             if(Ze_out(i,pr,radar_preclvl-1) .le. -15 .and. Ze_out(i,pr,radar_preclvl-1) .gt. -100) then
+             if(Ze_out(i,pr,radar_preclvl(i,pr)-1) .le. -15 .and. Ze_out(i,pr,radar_preclvl(i,pr)-1) .gt. -100) then
                 cloudsat_pflag(i,pr) =  pClass_noPrecip                     ! JEK: Not Precipitating
              endif         
           endif ! Land points
        enddo ! Sub-columns
+       cloudsat_precip_pia(i,:) = radar_preclvl(i,:)
+
     enddo    ! Gridpoints
 
     ! ######################################################################################
@@ -544,7 +548,7 @@ contains
              cloudsat_precip_cover(i,k) = count(cloudsat_pflag(i,:) .eq. k-1)
           endif
        enddo
-
+ 
        ! Gridmean path integrated attenuation (pia)
        cloudsat_pia(i)=sum(cloudsat_precip_pia(i,:))
     enddo
@@ -554,6 +558,9 @@ contains
          cloudsat_precip_cover = cloudsat_precip_cover / Ncolumns
     where ((cloudsat_pia/= R_UNDEF).and.(cloudsat_pia/= 0.0)) &
          cloudsat_pia = cloudsat_pia / Ncolumns 
+
+    cloudsat_precip_cover(:,8) = radar_preclvl(:,1)
+    cloudsat_pia = surfelev
 
   end subroutine cloudsat_precipOccurence
   

--- a/src/simulator/quickbeam/quickbeam.F90
+++ b/src/simulator/quickbeam/quickbeam.F90
@@ -518,7 +518,7 @@ contains
              endif
              
              ! No precipitation
-             if(Ze_out(i,pr,cloudsat_preclvl_index(i)-1) .le. -15 .and. Ze_out(i,pr,cloudsat_preclvl_index(i)-1) .gt. -100) then
+             if(Ze_out(i,pr,cloudsat_preclvl_index(i)-1) .le. -15) then
                 cloudsat_pflag(i,pr) =  pClass_noPrecip                     ! JEK: Not Precipitating
              endif         
           endif ! Land points


### PR DESCRIPTION
There is a bug in the CloudSat Precipitation Flag diagnostics. The computation of these flags is performed with information coming from the 2nd layer from the surface of the statistical CloudSat/Calipso grid (40 levels). However, the surface elevation was not taken into account for this calculation and the precipitation flags were wrong over land surfaces higher than 480m Above Sea Level.

This bug was discovered when implementing COSPv2.1 in the LMDZ model. The sample data provided with the standalone offline COSPv2 version does not allow to detect this bug because the 153 grid points of this dataset are over ocean. Indeed, performing the Python regression test provided with the offline COSPv2 after having corrected this CloudSat bug does not result in any difference between the diagnostics fields from the reference output file and the new output file ("All fields match"). We should consider adding land points to the sample data provided with COSPv2 in order to have a wider range of cases covered with this regression test.

All the lines that have been modified or added to fix this bug have a "!PREC_BUG" comment at the end of each of these lines. As a first step to discuss this provisional bug fix, the lines that have been replaced or removed from the code are left in the code as comments.