### PR TITLE
Make sure MISR outputs are masked for night columns

### DIFF
--- a/src/simulator/MISR_simulator/MISR_simulator.F90
+++ b/src/simulator/MISR_simulator/MISR_simulator.F90
@@ -213,9 +213,13 @@ contains
 !    ! DS2015 END
      
     ! Fill dark scenes 
-    do j=1,numMISRHgtBins
-       where(sunlit .ne. 1) dist_model_layertops(1:npoints,j) = R_UNDEF
-    enddo
+    do j = 1,npoints
+      if (sunlit(j) .ne. 1) then
+        dist_model_layertops(j,:) = R_UNDEF
+        box_MISR_ztop(j,:) = R_UNDEF
+        tauOUT(j,:) = R_UNDEF
+      end if
+    end do
 
   end SUBROUTINE MISR_SUBCOLUMN
 
@@ -284,6 +288,7 @@ contains
        else
           MISR_cldarea(j)         = R_UNDEF
           MISR_mean_ztop(npoints) = R_UNDEF
+          fq_MISR_TAU_v_CTH(j,:,:) = R_UNDEF
        endif
     enddo
 

--- a/src/simulator/MISR_simulator/MISR_simulator.F90
+++ b/src/simulator/MISR_simulator/MISR_simulator.F90
@@ -286,8 +286,8 @@ contains
           endif
 
        else
-          MISR_cldarea(j)         = R_UNDEF
-          MISR_mean_ztop(npoints) = R_UNDEF
+          MISR_cldarea(j)          = R_UNDEF
+          MISR_mean_ztop(j)        = R_UNDEF
           fq_MISR_TAU_v_CTH(j,:,:) = R_UNDEF
        endif
     enddo


### PR DESCRIPTION
Previously, the `fq_MISR_TAU_v_CTH` output variable from the `MISR_COLUMN` routine was left unmasked for night columns, and due to a typo most of `misr_meanztop` was left unmasked as well. The result of this was that the output joint histogram variable `clMISR` and the output cloud top height `misr_meanztop` would be left unmasked and instead misleadingly set to 0 for night columns. Since MISR retrievals should be set to fillvalue for night columns, we need to make sure all MISR outputs are masked appropriately when `sunlit == 0`. This PR applies the fix for these two fields in `MISR_COLUMN`, and also makes sure that output variables from the `MISR_SUBCOLUMN` routine are similarly masked (previously only `dist_model_layertops` was masked, while `box_MISR_ztop` and `tauOUT` were left unmasked. Fixes #30