### PR TITLE
Continuous integration

### DIFF
--- a/.github/workflows/continous_integration.yml
+++ b/.github/workflows/continous_integration.yml
@@ -90,4 +90,4 @@ jobs:
       uses: actions/upload-artifact@v1.0.0
       with:
         name: cosp2_output_um.nc
-        path: driver/data/outputs/cosp2_output_um.nc
+        path: driver/data/outputs/UKMO/cosp2_output_um.nc

--- a/.github/workflows/continous_integration.yml
+++ b/.github/workflows/continous_integration.yml
@@ -1,0 +1,93 @@
+# (c) British Crown Copyright 2020, the Met Office.
+# All rights reserved.
+# 
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 
+#   * Redistributions of source code must retain the above copyright notice,
+#     this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright notice,
+#     this list of conditions and the following disclaimer in the documentation
+#     and/or other materials provided with the distribution.
+#   * Neither the name of the Met Office nor the names of its contributors may
+#     be used to endorse or promote products derived from this softwarewithout
+#     specific prior written permission.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+
+# Workflow for continuous integration tests
+name: CI
+on: [push, pull_request]
+
+jobs:
+  # This workflow contains a single job called "test"
+  test:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        fortran-compiler: [gfortran, gfortran-8, gfortran-9]
+    env:
+      F90: ${{ matrix.fortran-compiler }}
+    # Sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out repository under $GITHUB_WORKSPACE
+    - uses: actions/checkout@v2
+    # Set up Python and install dependencies
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+    - name: Install python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r python_requirements.txt
+    # Install FORTRAN compiler and NetCDF libraries
+    - name: Install FORTRAN compiler and NetCDF
+      run: sudo apt-get install ${{ matrix.fortran-compiler }} libnetcdf-dev
+    # NetCDF FORTRAN library
+    - name: NetCDF FORTRAN library for standard gfortran
+      if: ${{ matrix.fortran-compiler == 'gfortran' }}
+      run: sudo apt-get install libnetcdff-dev
+    - name: NetCDF FORTRAN library for other gfortran
+      if: ${{ matrix.fortran-compiler != 'gfortran' }}
+      run: |
+        git clone https://github.com/Unidata/netcdf-fortran.git --branch v4.4.4
+        cd netcdf-fortran
+        ./configure --prefix=/usr
+        make
+        sudo make install
+    # Build COSP2 driver
+    - name: Build driver
+      run: |
+        cd build
+        make driver
+    # Run COSP2 test
+    - name: Run test
+      run: |
+        cd driver/run
+        ./cosp2_test
+    # Compare results against known good outputs
+    - name: Compare output against KGO
+      run: |
+        cd driver
+        KGO=data/outputs/UKMO/cosp2_output_um.ref.nc
+        TST=data/outputs/UKMO/cosp2_output_um.nc
+        python cosp2_test_01.py ${KGO} ${TST} --atol=0.0 --rtol=0.0
+    # Make output file available if the test fails
+    - name: Upload output file if test fails
+      if: failure()
+      uses: actions/upload-artifact@v1.0.0
+      with:
+        name: cosp2_output_um.nc
+        path: driver/data/outputs/cosp2_output_um.nc

--- a/.github/workflows/continous_integration.yml
+++ b/.github/workflows/continous_integration.yml
@@ -81,7 +81,7 @@ jobs:
     - name: Compare output against KGO
       run: |
         cd driver
-        KGO=data/outputs/UKMO/cosp2_output_um.ref.nc
+        KGO=data/outputs/UKMO/cosp2_output_um.gfortran.kgo.nc
         TST=data/outputs/UKMO/cosp2_output_um.nc
         python cosp2_test_01.py ${KGO} ${TST} --atol=0.0 --rtol=0.0
     # Make output file available if the test fails

--- a/.github/workflows/continous_integration.yml
+++ b/.github/workflows/continous_integration.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Install python dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r python_requirements.txt
+        pip install netCDF4 argparse numpy
     # Install FORTRAN compiler and NetCDF libraries
     - name: Install FORTRAN compiler and NetCDF
       run: sudo apt-get install ${{ matrix.fortran-compiler }} libnetcdf-dev
@@ -78,7 +78,7 @@ jobs:
         cd driver/run
         ./cosp2_test
     # Compare results against known good outputs
-    - name: Compare output against KGO
+    - name: Compare test output against known good output (KGO)
       run: |
         cd driver
         KGO=data/outputs/UKMO/cosp2_output_um.gfortran.kgo.nc

--- a/build/Makefile.conf
+++ b/build/Makefile.conf
@@ -1,5 +1,5 @@
-#F90      = ifort
-F90FLAGS = -O3 -ffree-line-length-none
+#F90      = gfortran
+F90FLAGS = -O3 -ffree-line-length-none -fcheck=bounds -finit-real=nan
 
 F90_LIB     = /usr
 NC_INC      = -I$(F90_LIB)/include

--- a/build/Makefile.conf
+++ b/build/Makefile.conf
@@ -1,5 +1,5 @@
 #F90      = ifort
-F90FLAGS = -O3
+F90FLAGS = -O3 -ffree-line-length-none
 
 F90_LIB     = /usr
 NC_INC      = -I$(F90_LIB)/include

--- a/build/Makefile.conf
+++ b/build/Makefile.conf
@@ -1,6 +1,6 @@
-F90      = ifort
+#F90      = ifort
 F90FLAGS = -O3
 
-F90_LIB     = /usr/local/ifort
+F90_LIB     = /usr
 NC_INC      = -I$(F90_LIB)/include
 NC_LIB      = -L$(F90_LIB)/lib

--- a/driver/cosp2_test_01.py
+++ b/driver/cosp2_test_01.py
@@ -40,7 +40,11 @@ def get_var_list(ncfile):
 
 def read_var(fname, vname):
     """
-    Returns the variable 'vname' in a NetCDF file.
+    Reads a variable from a NetCDF file.
+    
+    Arguments:
+        fname: path to NetCDF file.
+        vname: variable name.
     """
     f_id = netCDF4.Dataset(fname,'r')
     return f_id.variables[vname][:]

--- a/driver/cosp2_test_01.py
+++ b/driver/cosp2_test_01.py
@@ -1,0 +1,158 @@
+# (c) British Crown Copyright 2020, the Met Office.
+# All rights reserved.
+# 
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 
+#   * Redistributions of source code must retain the above copyright notice,
+#     this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright notice,
+#     this list of conditions and the following disclaimer in the documentation
+#     and/or other materials provided with the distribution.
+#   * Neither the name of the Met Office nor the names of its contributors may
+#     be used to endorse or promote products derived from this softwarewithout
+#     specific prior written permission.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+
+import netCDF4,argparse,sys
+import numpy as np
+
+def get_var_list(ncfile):
+    """
+    Returns a list with the names of the variables in a NetCDF file.
+    """
+    dataset = netCDF4.Dataset(ncfile)
+    var_list = dataset.variables.keys()
+    dataset.close()
+    return var_list
+    
+
+def read_var(fname, vname):
+    """
+    Returns the variable 'vname' in a NetCDF file.
+    """
+    f_id = netCDF4.Dataset(fname,'r')
+    return f_id.variables[vname][:]
+
+def calculate_stats(tst, kgo, atol=0.0, rtol=None):
+    """
+    Returns a dictionary with some basic summary statistics of the differences
+    between two numpy arrays. The dictionary contains the following keys:
+        'N': number of differences.
+        'AvgDiff': average difference.
+        'MinDiff': minimum difference.
+        'MaxDiff': maximum difference.
+        'StDev': standard deviation of the differences.
+    
+    Arguments:
+        tst: test variable (numpy array).
+        kgo: reference variable (numpy array).
+    Keyword arguments:
+        atol: absolute tolerance threshold. Smaller differences pass the test.
+        rtol: relative tolerance threshold. Smaller differences pass the test.
+    
+    """
+    summary_stats = {'N':0, 'AvgDiff':0.0, 'MinDiff':0.0, 'MaxDiff':0.0, 'StDev':0.0}
+    # All differences
+    d = tst - kgo
+    # Mask for differences larger than absolute tolerance
+    maskAllDiff = (np.absolute(d) > atol)
+    NallDiff = maskAllDiff.sum()
+    # If there are differences larger than atol,
+    # then calculate summary statsitics
+    if (NallDiff > 0):
+        diffs = d[maskAllDiff]
+        # Are relative differences requested?
+        if rtol is not None:
+            # Calculate relative differences. When KGO=0,
+            # use test as reference (i.e. relative diff will
+            # be 1 or -1)
+            maskedKgo = kgo[maskAllDiff]
+            rdiffs = diffs / maskedKgo
+            rdiffs[maskedKgo == 0.0] = np.sign(diffs[maskedKgo == 0.0])
+            # Keep only those diffs larger than relative tolerance
+            diffs = diffs[np.absolute(rdiffs) > rtol]
+            NallDiff = len(diffs)
+        # Calculate summary stats
+        summary_stats['N'] = NallDiff
+        if NallDiff > 0:
+            summary_stats['AvgDiff'] = diffs.mean()
+            summary_stats['MinDiff'] = diffs.min()
+            summary_stats['MaxDiff'] = diffs.max()
+            summary_stats['StDev'] = diffs.std()
+        
+    return summary_stats
+
+def print_stats_table(summary_stats):
+    """
+    Print table of summary statistics.
+    """
+    for key, s in summary_stats.items():
+        print(key,s)
+
+#######################
+# Main
+#######################
+if __name__ == '__main__':
+
+    # Command line arguments
+    parser = argparse.ArgumentParser()
+    parser.add_argument("kgo_file", help="File with known good outputs.")
+    parser.add_argument("tst_file", help="Test output file.")
+    parser.add_argument("--atol",type=float,
+                        default=0.0,help="Absolute tolerance.")
+    parser.add_argument("--rtol",type=float,
+                        default=None,help="Relative tolerance.")
+    args = parser.parse_args()
+
+    # Get list of variables
+    kgo_vars = get_var_list(args.kgo_file)
+    tst_vars = get_var_list(args.tst_file)
+    nkgo = len(kgo_vars)
+    ntst = len(tst_vars)
+
+    # Dictionary for summary statistics
+    summary_stats = {}
+
+    # Iterate over shortest list and calculate stats
+    errored = False
+    if (nkgo <= ntst):
+        vlst = kgo_vars
+    else:
+        vlst = tst_vars
+    for vname in vlst:
+        kgo = read_var(args.kgo_file, vname) # KGO
+        tst = read_var(args.tst_file, vname) # test
+        summary_stats[vname] = calculate_stats(tst, kgo, 
+                                               atol=args.atol, rtol=args.rtol)
+        if summary_stats[vname]['N'] > 0: errored = True
+
+    # Print summary stats
+    print_stats_table(summary_stats)
+    
+    # Error if files have different number variables. If the number 
+    # of variables is the same but they have different names, it will
+    # fail in summary_stats.
+    if (nkgo != ntst):
+        errored = True
+        print("=== Variables in KGO ===")
+        print(kgo_vars)
+        print("=== Variables in Test ===")
+        print(tst_vars)
+
+    # Exit with correct error condition
+    if errored:
+        sys.exit(1)
+    else:
+        sys.exit()

--- a/driver/cosp2_test_01.py
+++ b/driver/cosp2_test_01.py
@@ -105,7 +105,7 @@ def print_stats_table(summary_stats, print_all=False):
     Print table of summary statistics.
     
     Arguments:
-      summary_stats: dictionary with summary statts. Output from called
+      summary_stats: dictionary with summary statistics. Output from call
                      to function calculate_stats.
 
     Keywords:

--- a/python_requirements.txt
+++ b/python_requirements.txt
@@ -1,0 +1,3 @@
+netCDF4
+argparse
+numpy

--- a/python_requirements.txt
+++ b/python_requirements.txt
@@ -1,3 +1,0 @@
-netCDF4
-argparse
-numpy


### PR DESCRIPTION
Implementation of continuous integration workflow. It follows the same steps that we currently request when testing branches. The main differences are:

   * It uses gfortran, which changes the outputs. The changes are generally smaller than 0.07%. CALIPSO backscatter calculations show bigger relative errors, but for very small absolute differences (<1.0e-37).

   * I have developed a new python test script that runs in python 3.

   * The new reference file (a.k.a. KGO: known good output) contains new variables. I believe these variables were introduced in #14, but the reference file was not updated. 
