### PR TITLE
Adding ifort to continuous itegration tests

### DIFF
--- a/.github/workflows/continous_integration.yml
+++ b/.github/workflows/continous_integration.yml
@@ -99,6 +99,7 @@ jobs:
     # Run COSP2 test
     - name: Run test
       run: |
+        source /opt/intel/inteloneapi/setvars.sh || true
         cd driver/run
         ./cosp2_test
     # Compare results against known good outputs

--- a/.github/workflows/continous_integration.yml
+++ b/.github/workflows/continous_integration.yml
@@ -89,7 +89,8 @@ jobs:
     # Build COSP2 driver
     - name: Build driver
       run: |
-        if [[ $(ifort --version) ]]; then
+        if [[ -e /opt/intel/inteloneapi/setvars.sh ]]; then
+          source /opt/intel/inteloneapi/setvars.sh;
           ifort --version
           export F90FLAGS="-O3"
         fi

--- a/.github/workflows/continous_integration.yml
+++ b/.github/workflows/continous_integration.yml
@@ -36,9 +36,10 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        fortran-compiler: [gfortran, gfortran-8, gfortran-9]
+        fortran-compiler: [gfortran, gfortran-8, gfortran-9, ifort]
     env:
       F90: ${{ matrix.fortran-compiler }}
+      F90FLAGS: "-O3 -ffree-line-length-none -fcheck=bounds -finit-real=nan"
     # Sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out repository under $GITHUB_WORKSPACE
@@ -52,21 +53,44 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install netCDF4 argparse numpy
-    # Install FORTRAN compiler and NetCDF libraries
-    - name: Install FORTRAN compiler and NetCDF
-      run: sudo apt-get install ${{ matrix.fortran-compiler }} libnetcdf-dev
+    # Install FORTRAN compiler
+    - name: Install gfortran compiler and NetCDF
+      if: ${{ matrix.fortran-compiler != 'ifort' }}
+      run: sudo apt-get install ${{ matrix.fortran-compiler }}
+    # Intel compilers and libraries if needed
+    #   https://software.intel.com/content/www/us/en/develop/articles/oneapi-repo-instructions.html#aptpkg
+    - name: Install Intel compilers and libraries
+      if: ${{ matrix.fortran-compiler == 'ifort' }}
+      run: |
+        wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+        sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+        sudo add-apt-repository "deb https://apt.repos.intel.com/oneapi all main"
+        sudo apt-get update
+        sudo apt-get install intel-oneapi-common-licensing
+        sudo apt-get install intel-oneapi-common-vars
+        sudo apt-get install intel-oneapi-dev-utilities
+        sudo apt-get install intel-oneapi-ifort
+    # Install NetCDF library
+    - name: Install NetCDF library
+      run: sudo apt-get install libnetcdf-dev
     # NetCDF FORTRAN library
-    - name: NetCDF FORTRAN library for standard gfortran
+    - name: Install NetCDF FORTRAN library for standard gfortran
       if: ${{ matrix.fortran-compiler == 'gfortran' }}
       run: sudo apt-get install libnetcdff-dev
-    - name: NetCDF FORTRAN library for other gfortran
+    - name: Build NetCDF FORTRAN library
       if: ${{ matrix.fortran-compiler != 'gfortran' }}
       run: |
+        source /opt/intel/inteloneapi/setvars.sh || true
         git clone https://github.com/Unidata/netcdf-fortran.git --branch v4.4.4
         cd netcdf-fortran
         ./configure --prefix=/usr
         make
         sudo make install
+    # Environment variables for COSP build
+    - name: Environment variables for COSP build
+      if: ${{ matrix.fortran-compiler == 'ifort' }}
+      env:
+        F90FLAGS: "-O3"
     # Build COSP2 driver
     - name: Build driver
       run: |

--- a/.github/workflows/continous_integration.yml
+++ b/.github/workflows/continous_integration.yml
@@ -40,6 +40,8 @@ jobs:
     env:
       F90: ${{ matrix.fortran-compiler }}
       F90FLAGS: "-O3 -ffree-line-length-none -fcheck=bounds -finit-real=nan"
+      ATOL: 0.0
+      RTOL: 0.0
     # Sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out repository under $GITHUB_WORKSPACE
@@ -105,10 +107,14 @@ jobs:
     # Compare results against known good outputs
     - name: Compare test output against known good output (KGO)
       run: |
+        if [[ -e /opt/intel/inteloneapi/setvars.sh ]]; then
+          ATOL=1.0e-20
+          RTOL=0.0006
+        fi
         cd driver
         KGO=data/outputs/UKMO/cosp2_output_um.gfortran.kgo.nc
         TST=data/outputs/UKMO/cosp2_output_um.nc
-        python compare_to_kgo.py ${KGO} ${TST} --atol=0.0 --rtol=0.0
+        python compare_to_kgo.py ${KGO} ${TST} --atol=${ATOL} --rtol=${RTOL}
     # Make output file available if the test fails
     - name: Upload output file if test fails
       if: failure()

--- a/.github/workflows/continous_integration.yml
+++ b/.github/workflows/continous_integration.yml
@@ -89,8 +89,7 @@ jobs:
     # Environment variables for COSP build
     - name: Environment variables for COSP build
       if: ${{ matrix.fortran-compiler == 'ifort' }}
-      env:
-        F90FLAGS: "-O3"
+      run: export F90FLAGS="-O3"
     # Build COSP2 driver
     - name: Build driver
       run: |

--- a/.github/workflows/continous_integration.yml
+++ b/.github/workflows/continous_integration.yml
@@ -86,13 +86,13 @@ jobs:
         ./configure --prefix=/usr
         make
         sudo make install
-    # Environment variables for COSP build
-    - name: Environment variables for COSP build
-      if: ${{ matrix.fortran-compiler == 'ifort' }}
-      run: export F90FLAGS="-O3"
     # Build COSP2 driver
     - name: Build driver
       run: |
+        if [[ $(ifort --version) ]]; then
+          ifort --version
+          export F90FLAGS="-O3"
+        fi
         cd build
         make driver
     # Run COSP2 test

--- a/build/Makefile.conf
+++ b/build/Makefile.conf
@@ -1,5 +1,5 @@
 #F90      = gfortran
-F90FLAGS = -O3 -ffree-line-length-none -fcheck=bounds -finit-real=nan
+#F90FLAGS = -O3 -ffree-line-length-none -fcheck=bounds -finit-real=nan
 
 F90_LIB     = /usr
 NC_INC      = -I$(F90_LIB)/include


### PR DESCRIPTION
I am adding ifort to the matrix of compilers used in the CI tests. It follows the example developed by @RobertPincus  in one of his projects. Currently, it tests ifort outputs against the gfortran KGO, using relaxed tolerances. We might want to do a strict regression test against ifort KGO instead.