### PR TITLE
Variables related to liquid reff are not correct

### DIFF
--- a/driver/src/cosp2_io.f90
+++ b/driver/src/cosp2_io.f90
@@ -5,7 +5,7 @@ module mod_cosp_io
   USE MOD_COSP_CONFIG, ONLY:  Nlvgrid, LIDAR_NCAT, SR_BINS, PARASOL_NREFL, cloudsat_DBZE_BINS, &
        numMODISReffIceBins, numMODISReffLiqBins, ntau, tau_binBounds, tau_binCenters, &
        tau_binEdges,npres, pres_binBounds, pres_binCenters, pres_binEdges, nhgt,      &
-       hgt_binBounds, hgt_binCenters, hgt_binEdges, reffLIQ_binCenters,vgrid_z,       &
+       hgt_binBounds, hgt_binCenters, hgt_binEdges, vgrid_z,                          &
        reffICE_binCenters, reffLIQ_binCenters, cloudsat_binCenters, PARASOL_SZA,      &
        calipso_binCenters, grLidar532_binCenters, atlid_binCenters,                   &
        CFODD_NDBZE,  CFODD_HISTDBZE, CFODD_HISTDBZEcenters,                           &

--- a/src/cosp_config.F90
+++ b/src/cosp_config.F90
@@ -142,7 +142,7 @@ MODULE MOD_COSP_CONFIG
                                     shape = (/2,nReffICE/)) 
     real(wp),parameter,dimension(2,nReffLIQ) :: &
          reffLIQ_binEdges = reshape(source=(/reffLIQ_binBounds(1),((reffLIQ_binBounds(k),  &
-                                    l=1,2),k=2,nReffLIQ),reffLIQ_binBounds(nReffICE+1)/),  &
+                                    l=1,2),k=2,nReffLIQ),reffLIQ_binBounds(nReffLIQ+1)/),  &
                                     shape = (/2,nReffLIQ/))             
     real(wp),parameter,dimension(nReffICE) :: &
          reffICE_binCenters = (reffICE_binEdges(1,:)+reffICE_binEdges(2,:))/2._wp
@@ -265,8 +265,8 @@ MODULE MOD_COSP_CONFIG
     real(wp),parameter,dimension(nReffLiq+1) :: &
          modis_histReffLiq = reffLIQ_binBounds         ! Effective radius bin boundaries 
     real(wp),parameter,dimension(nReffLiq) :: &
-         modis_histReffLiqCenters = reffICE_binCenters ! Effective radius bin centers
-    real(wp),parameter,dimension(2,nReffICE) :: &
+         modis_histReffLiqCenters = reffLIQ_binCenters ! Effective radius bin centers
+    real(wp),parameter,dimension(2,nReffLiq) :: &
          modis_histReffLiqEdges = reffLIQ_binEdges     ! Effective radius bin edges
 
     ! ####################################################################################


### PR DESCRIPTION
In `cosp_config.F90`,  the liquid `Reff` related variables should use `LIQ` rather than `ICE`, right? 
I notice that `nReffICE` and `nReffLIQ` are equal, so the misuse of them won't cause any problems. However,  `reffICE_binCenters` and `reffLIQ_binCenters` are different, which needs to be corrected.