### PR TITLE
CI: ifort fix, nvfortran support (not enabled)

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -119,7 +119,7 @@ jobs:
     # Cache netcdf FORTRAN library
     - name: cache-netcdf-fortran
       id: cache-netcdf-fortran
-      uses: actions/cache@v2.1.1
+      uses: actions/cache@v2
       with:
         path: /home/runner/netcdf-fortran
         key: netcdf-fortran-4.4.4-${{ runner.os }}-${{ matrix.fortran-compiler }}

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        fortran-compiler: [gfortran, gfortran-8, gfortran-9, ifort, nvfortran]
+        fortran-compiler: [gfortran, gfortran-8, gfortran-9, nvfortran]
     env:
       F90: ${{ matrix.fortran-compiler }}
       F90FLAGS: "-O3 -ffree-line-length-none -fcheck=bounds -finit-real=nan"

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -86,14 +86,19 @@ jobs:
 
     # https://software.intel.com/content/www/us/en/develop/articles/installing-intel-oneapi-toolkits-via-apt.html
     - name: Install Intel compilers and libraries
-      if: ${{ matrix.fortran-compiler == 'ifort' }} && steps.cache-intel-compilers.outputs.cache-hit != 'true'
+      if: contains(matrix.fortran-compiler, 'ifort') && steps.cache-intel-compilers.outputs.cache-hit != 'true'
       run: |
         wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
         sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
         sudo add-apt-repository "deb https://apt.repos.intel.com/oneapi all main"
         sudo apt-get update
-        sudo apt-get install intel-basekit
-        sudo apt-get install intel-hpckit
+#        sudo apt-get install intel-basekit
+#        sudo apt-get install intel-hpckit
+        sudo apt-get install intel-oneapi-common-licensing
+        sudo apt-get install intel-oneapi-common-vars
+        sudo apt-get install intel-oneapi-dev-utilities
+        sudo apt-get install intel-oneapi-icc
+        sudo apt-get install intel-oneapi-ifort
 
     #
     # Nvidia compilers

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -119,9 +119,9 @@ jobs:
     # Cache netcdf FORTRAN library
     - name: cache-netcdf-fortran
       id: cache-netcdf-fortran
-      uses: actions/cache@v2
+      uses: actions/cache@v2.1.1
       with:
-        path: ${NFHOME}
+        path: /home/runner/netcdf-fortran
         key: netcdf-fortran-4.4.4-${{ runner.os }}-${{ matrix.fortran-compiler }}
     # Build NetCDF FORTRAN library for all compilers
     - name: Build NetCDF FORTRAN library

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -121,9 +121,9 @@ jobs:
     ###############################################################################
     # Environments for ifort and nvidia compilers
     - name: Environment for ifort compiler
-      if: ${{ matrix.fortran-compiler == 'ifort' }}
+      if: contains(matrix.fortran-compiler, 'ifort')
       run: |
-        echo "::set-env name=CC::icx"
+        echo "::set-env name=CC::icc"
         echo "::set-env name=FC::ifort"
         echo "::set-env name=F90FLAGS::-O3 -heap-arrays"
     - name: Environment for nvfortran compiler
@@ -144,7 +144,6 @@ jobs:
 
     # Cache netcdf FORTRAN library
     - name: cache-netcdf-fortran
-      if: False
       id: cache-netcdf-fortran
       uses: actions/cache@v2
       with:

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -118,7 +118,6 @@ jobs:
       run: sudo apt-get install libnetcdf-dev
     # Cache netcdf FORTRAN library
     - name: cache-netcdf-fortran
-      if: False
       id: cache-netcdf-fortran
       uses: actions/cache@v2
       with:

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -44,6 +44,7 @@ jobs:
       ATOL: 0.0
       RTOL: 0.0
       NFHOME: /home/runner/netcdf-fortran
+      LD_LIBRARY_PATH: ${LD_LIBRARY_PATH}:${NFHOME}/lib
     # Sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out repository under $GITHUB_WORKSPACE

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -116,13 +116,6 @@ jobs:
     # NetCDF C library
     - name: Install NetCDF library
       run: sudo apt-get install libnetcdf-dev
-    # Cache netcdf FORTRAN library
-    - name: cache-netcdf-fortran
-      id: cache-netcdf-fortran
-      uses: actions/cache@v2.1.1
-      with:
-        path: /home/runner/netcdf-fortran
-        key: netcdf-fortran-4.4.4-${{ runner.os }}-${{ matrix.fortran-compiler }}
     # Build NetCDF FORTRAN library for all compilers
     - name: Build NetCDF FORTRAN library
       env:
@@ -136,6 +129,13 @@ jobs:
         ./configure --prefix=${NFHOME}
         make
         sudo make install
+    # Cache netcdf FORTRAN library
+    - name: cache-netcdf-fortran
+      id: cache-netcdf-fortran
+      uses: actions/cache@v2.1.1
+      with:
+        path: /home/runner/netcdf-fortran
+        key: netcdf-fortran-4.4.4-${{ runner.os }}-${{ matrix.fortran-compiler }}
     ###############################################################################
     # Build COSP and retrieve input and test files
     ###############################################################################

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -44,7 +44,6 @@ jobs:
       ATOL: 0.0
       RTOL: 0.0
       NFHOME: /home/runner/netcdf-fortran
-      LD_LIBRARY_PATH: ${LD_LIBRARY_PATH}:${NFHOME}/lib
     # Sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out repository under $GITHUB_WORKSPACE
@@ -62,6 +61,9 @@ jobs:
     # Update system packages
     - name: Update system packages
       run: sudo apt-get update
+    # Non compiler-specific environment
+    - name: Non compiler-specific environment
+      run: export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${NFHOME}/lib
     ###############################################################################
     # FORTRAN compilers
     ###############################################################################
@@ -172,6 +174,7 @@ jobs:
       run: |
         source /opt/intel/oneapi/setvars.sh || true
         cd driver/run
+        echo ${LD_LIBRARY_PATH}
         ./cosp2_test cosp2_input_nl.txt
     # 2. UM global snapshot
     - name: UM global snapshot

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -44,7 +44,7 @@ jobs:
       ATOL: 0.0
       RTOL: 0.0
       NFHOME: /home/runner/netcdf-fortran
-      LD_LIBRARY_PATH: ${NFHOME}/lib
+      LD_LIBRARY_PATH: /home/runner/netcdf-fortran/lib
     # Sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out repository under $GITHUB_WORKSPACE

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        fortran-compiler: [gfortran, gfortran-8, gfortran-9, ifort]
+        fortran-compiler: [gfortran, gfortran-8, gfortran-9, ifort, nvfortran]
     env:
       F90: ${{ matrix.fortran-compiler }}
       F90FLAGS: "-O3 -ffree-line-length-none -fcheck=bounds -finit-real=nan"
@@ -71,7 +71,24 @@ jobs:
         sudo apt-get install intel-oneapi-dev-utilities
         sudo apt-get install intel-oneapi-icc
         sudo apt-get install intel-oneapi-ifort
-    # Install NetCDF library
+    # Nvidia compilers
+    - name: Nvidia setup compilers
+      env:
+        NVCOMPILERS: /opt/nvidia/hpc_sdk
+      if: contains(matrix.fortran-compiler, 'nvfortran') && steps.cache-nvidia-compilers.outputs.cache-hit != 'true'
+      run: |
+        wget -q https://developer.download.nvidia.com/hpc-sdk/nvhpc-20-7_20.7_amd64.deb https://developer.download.nvidia.com/hpc-sdk/nvhpc-2020_20.7_amd64.deb
+        sudo apt-get install ./nvhpc-20-7_20.7_amd64.deb ./nvhpc-2020_20.7_amd64.deb
+    - name: Nvidia environment
+      env:
+        NVCOMPILERS: /opt/nvidia/hpc_sdk
+      if: contains(matrix.fortran-compiler, 'nvfortran')
+      run: |
+        echo "::set-env name=FC::nvfortran"
+        echo "::set-env name=CC::nvc"
+        echo "::set-env name=FCFLAGS::-Mallocatable=03 -Mstandard -Mbounds -Mchkptr -Kieee -Mchkstk"
+        echo "::add-path::${NVCOMPILERS}/Linux_x86_64/20.7/compilers/bin"    # Install NetCDF library
+    # NetCDF C library
     - name: Install NetCDF library
       run: |
         sudo apt-get update
@@ -84,6 +101,7 @@ jobs:
       if: ${{ matrix.fortran-compiler != 'gfortran' }}
       run: |
         source /opt/intel/oneapi/setvars.sh || true
+        ${F90} --version
         git clone https://github.com/Unidata/netcdf-fortran.git --branch v4.4.4
         cd netcdf-fortran
         if [ -f /opt/intel/oneapi/setvars.sh ]; then
@@ -101,7 +119,7 @@ jobs:
       run: |
         source /opt/intel/oneapi/setvars.sh || true
         if [ -f /opt/intel/oneapi/setvars.sh ]; then
-          ifort --version
+          ${F90} --version
           export F90FLAGS="-O3 -heap-arrays"
         fi
         cd build

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -96,7 +96,7 @@ jobs:
         sudo apt-get install intel-hpckit
 
     #
-    # Nvidia compilers 
+    # Nvidia compilers
     #
     - name: cache-nvidia-compilers
       id: cache-nvidia-compilers
@@ -110,7 +110,6 @@ jobs:
       if: contains(matrix.fortran-compiler, 'nvfortran') && steps.cache-nvidia-compilers.outputs.cache-hit != 'true'
       env:
         NVCOMPILERS: /opt/nvidia/hpc_sdk
-      if: contains(matrix.fortran-compiler, 'nvfortran') && steps.cache-nvidia-compilers.outputs.cache-hit != 'true'
       run: |
         wget -q https://developer.download.nvidia.com/hpc-sdk/nvhpc-20-7_20.7_amd64.deb https://developer.download.nvidia.com/hpc-sdk/nvhpc-2020_20.7_amd64.deb
         sudo apt-get install ./nvhpc-20-7_20.7_amd64.deb ./nvhpc-2020_20.7_amd64.deb

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -118,7 +118,8 @@ jobs:
       run: sudo apt-get install libnetcdf-dev
     # Cache netcdf FORTRAN library
     - name: cache-netcdf-fortran
-      id: cache-netcdff
+      if: False
+      id: cache-netcdf-fortran
       uses: actions/cache@v2
       with:
         path: /home/runner/netcdf-fortran
@@ -127,7 +128,7 @@ jobs:
     - name: Build NetCDF FORTRAN library
       env:
         FCFLAGS: -fPIC
-      if: steps.cache-netcdff.outputs.cache-hit != 'true'
+      if: steps.cache-netcdf-fortran.outputs.cache-hit != 'true'
       run: |
         source /opt/intel/oneapi/setvars.sh || true
         ${F90} --version

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -88,9 +88,11 @@ jobs:
       uses: actions/cache@v2
       with:
         path: /opt/intel
-        key: intel-${{ runner.os }}-compilers-a
+        key: intel-${{ runner.os }}-compilers-b
 
     # https://software.intel.com/content/www/us/en/develop/articles/installing-intel-oneapi-toolkits-via-apt.html
+    # List of packages from Docler file at
+    #    https://github.com/intel/oneapi-containers/blob/master/images/docker/hpckit-devel-ubuntu18.04/Dockerfile
     - name: Install Intel compilers and libraries
       if: contains(matrix.fortran-compiler, 'ifort') && steps.cache-intel-compilers.outputs.cache-hit != 'true'
       run: |
@@ -98,9 +100,8 @@ jobs:
         sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
         sudo add-apt-repository "deb https://apt.repos.intel.com/oneapi all main"
         sudo apt-get update
-        sudo -E apt-cache pkgnames intel | grep oneapi | sort | grep -v beta
         sudo apt-get install intel-hpckit-getting-started intel-oneapi-clck intel-oneapi-common-licensing intel-oneapi-common-vars
-        sudo apt-get install intel-oneapi-dev-utilities  intel-oneapi-dpcpp-cpp-compiler-pro intel-oneapi-ifort intel-oneapi-inspector intel-oneapi-itac
+        sudo apt-get install intel-oneapi-dev-utilities  intel-oneapi-dpcpp-cpp-compiler-pro intel-oneapi-ifort intel-oneapi-itac
 
     #
     # Nvidia compilers

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        fortran-compiler: [ifort]
+        fortran-compiler: [gfortran, gfortran-8]
     env:
       F90: ${{ matrix.fortran-compiler }}
       FC: ${{ matrix.fortran-compiler }}
@@ -47,6 +47,9 @@ jobs:
     steps:
     # Checks-out repository under $GITHUB_WORKSPACE
     - uses: actions/checkout@v2
+    ###############################################################################
+    # Initial steps 
+    ###############################################################################
     # Set up Python and install dependencies
     - name: Set up Python
       uses: actions/setup-python@v1
@@ -57,6 +60,9 @@ jobs:
     # Update system packages
     - name: Update system packages
       run: sudo apt-get update
+    ###############################################################################
+    # FORTRAN compilers
+    ###############################################################################
     # Install gfortran compiler
     - name: Install gfortran compiler
       if: contains(matrix.fortran-compiler, 'gfortran')
@@ -80,6 +86,9 @@ jobs:
       run: |
         wget -q https://developer.download.nvidia.com/hpc-sdk/nvhpc-20-7_20.7_amd64.deb https://developer.download.nvidia.com/hpc-sdk/nvhpc-2020_20.7_amd64.deb
         sudo apt-get install ./nvhpc-20-7_20.7_amd64.deb ./nvhpc-2020_20.7_amd64.deb
+    ###############################################################################
+    # Compiler-specific environment
+    ###############################################################################
     # Environments for ifort and nvidia compilers
     - name: Environment for ifort compiler
       if: ${{ matrix.fortran-compiler == 'ifort' }}
@@ -96,17 +105,28 @@ jobs:
         echo "::set-env name=FC::nvfortran"
         echo "::set-env name=F90FLAGS::"
         echo "::add-path::${NVCOMPILERS}/Linux_x86_64/20.7/compilers/bin"
+    ###############################################################################
+    # NetCDF C and FORTRAN libraries
+    ###############################################################################
     # NetCDF C library
     - name: Install NetCDF library
       run: sudo apt-get install libnetcdf-dev
-    # NetCDF FORTRAN library
+    # NetCDF FORTRAN library from package repository
     - name: Install NetCDF FORTRAN library for standard gfortran
       if: ${{ matrix.fortran-compiler == 'gfortran' }}
       run: sudo apt-get install libnetcdff-dev
+    # Cache netcdf FORTRAN library
+    - name: cache-netcdf-fortran
+      id: cache-netcdf-fortran
+      uses: actions/cache@v2
+      with:
+        path: /home/runner/netcdf-fortran
+        key: netcdf-fortran-4.4.4-${{ runner.os }}-${{ matrix.fortran-compiler }}
+    # Build NetCDF FORTRAN library for all compilers but gfortran
     - name: Build NetCDF FORTRAN library
       env:
-        FCFLAGS: -fPIC 
-      if: ${{ matrix.fortran-compiler != 'gfortran' }}
+        FCFLAGS: -fPIC
+      if: ${{ matrix.fortran-compiler != 'gfortran' }} && steps.cache-netcdf-fortran.outputs.cache-hit != 'true'
       run: |
         source /opt/intel/oneapi/setvars.sh || true
         ${F90} --version
@@ -115,6 +135,9 @@ jobs:
         ./configure --prefix=/usr
         make
         sudo make install
+    ###############################################################################
+    # Build COSP and retrieve input and test files
+    ###############################################################################
     # Build COSP2 driver. Intel Fortran stores automatic arrays in the stack
     # by default, whereas GNU Fortran stores them in the heap. This can cause 
     # segmentation faults with ifort, especially in memory-intensive applications
@@ -141,8 +164,10 @@ jobs:
         gunzip ${OUTPATH}
         cd driver/data/outputs/UKMO
         md5sum -c cosp2_output.um_global.gfortran.kgo.nc.md5
+    ###############################################################################
     # Run COSP2 tests. We could run both tests in one step, but 
     # doing it this way the output is easier to interpret.
+    ###############################################################################
     # 1. Basic test
     - name: Basic test
       run: |
@@ -155,8 +180,10 @@ jobs:
         source /opt/intel/oneapi/setvars.sh || true
         cd driver/run
         ./cosp2_test cosp2_input_nl.um_global.txt
+    ###############################################################################
     # Compare results against known good outputs. As above,
     # we split it in as many steps as tests.
+    ###############################################################################
     # 1. Basic test
     - name: Basic against known good output (KGO)
       run: |
@@ -191,8 +218,10 @@ jobs:
         else
           python compare_to_kgo.py ${KGO} ${TST} --atol=${ATOL} --rtol=${RTOL}
         fi
+    ###############################################################################
     # Produce plots when it fails during global snapshot test,
     # and create a tarball with outputs.
+    ###############################################################################
     - name: Produce plots and create tarball
       if: failure()
       run: |
@@ -206,7 +235,9 @@ jobs:
         tar --ignore-failed-read -czf outputs.UKMO.tgz cosp2_output.um_global.nc \
           cosp2_output_um.nc *.png cosp2_output.um_global.out
         ls -lh
+    ###############################################################################
     # Make output files available any test fails
+    ###############################################################################
     - name: Upload output file if test fails
       if: failure()
       uses: actions/upload-artifact@v1.0.0

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        fortran-compiler: [gfortran]
+        fortran-compiler: [gfortran, gfortran-8, gfortran-9, ifort]
     env:
       F90: ${{ matrix.fortran-compiler }}
       FC: ${{ matrix.fortran-compiler }}

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -99,6 +99,8 @@ jobs:
       if: ${{ matrix.fortran-compiler == 'gfortran' }}
       run: sudo apt-get install libnetcdff-dev
     - name: Build NetCDF FORTRAN library
+      env:
+        FCFLAGS: -fPIC 
       if: ${{ matrix.fortran-compiler != 'gfortran' }}
       run: |
         source /opt/intel/oneapi/setvars.sh || true

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -1,9 +1,9 @@
 # (c) British Crown Copyright 2020, the Met Office.
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
+#
 #   * Redistributions of source code must retain the above copyright notice,
 #     this list of conditions and the following disclaimer.
 #   * Redistributions in binary form must reproduce the above copyright notice,
@@ -12,7 +12,7 @@
 #   * Neither the name of the Met Office nor the names of its contributors may
 #     be used to endorse or promote products derived from this softwarewithout
 #     specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -50,7 +50,7 @@ jobs:
     # Checks-out repository under $GITHUB_WORKSPACE
     - uses: actions/checkout@v2
     ###############################################################################
-    # Initial steps 
+    # Initial steps
     ###############################################################################
     # Set up Python and install dependencies
     - name: Set up Python
@@ -72,10 +72,21 @@ jobs:
     - name: Install gfortran compiler
       if: contains(matrix.fortran-compiler, 'gfortran')
       run: sudo apt-get install ${{ matrix.fortran-compiler }}
-    # Intel compilers and libraries if needed
+
+    #
+    # Intel compilers
+    #
+    - name: cache-intel-compilers
+      id: cache-intel-compilers
+      if: contains(matrix.fortran-compiler, 'ifort')
+      uses: actions/cache@v2
+      with:
+        path: /opt/intel
+        key: intel-${{ runner.os }}-compilers
+
     # https://software.intel.com/content/www/us/en/develop/articles/installing-intel-oneapi-toolkits-via-apt.html
     - name: Install Intel compilers and libraries
-      if: ${{ matrix.fortran-compiler == 'ifort' }}
+      if: ${{ matrix.fortran-compiler == 'ifort' }} && steps.cache-intel-compilers.outputs.cache-hit != 'true'
       run: |
         wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
         sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
@@ -83,8 +94,20 @@ jobs:
         sudo apt-get update
         sudo apt-get install intel-basekit
         sudo apt-get install intel-hpckit
-    # Nvidia compilers
+
+    #
+    # Nvidia compilers 
+    #
+    - name: cache-nvidia-compilers
+      id: cache-nvidia-compilers
+      if: contains(matrix.fortran-compiler, 'nvfortran')
+      uses: actions/cache@v2
+      with:
+        path: /opt/nvidia/hpc_sdk/
+        key: nvhpc-${{ runner.os }}-2020-20.7
+
     - name: Nvidia setup compilers
+      if: contains(matrix.fortran-compiler, 'nvfortran') && steps.cache-nvidia-compilers.outputs.cache-hit != 'true'
       env:
         NVCOMPILERS: /opt/nvidia/hpc_sdk
       if: contains(matrix.fortran-compiler, 'nvfortran') && steps.cache-nvidia-compilers.outputs.cache-hit != 'true'
@@ -116,6 +139,7 @@ jobs:
     # NetCDF C library
     - name: Install NetCDF library
       run: sudo apt-get install libnetcdf-dev
+
     # Cache netcdf FORTRAN library
     - name: cache-netcdf-fortran
       if: False
@@ -124,7 +148,8 @@ jobs:
       with:
         path: /home/runner/netcdf-fortran
         key: netcdf-fortran-4.4.4-${{ runner.os }}-${{ matrix.fortran-compiler }}
-    # Build NetCDF FORTRAN library for all compilers
+
+    # Build NetCDF FORTRAN library for current compiler
     - name: Build NetCDF FORTRAN library
       env:
         FCFLAGS: -fPIC
@@ -141,7 +166,7 @@ jobs:
     # Build COSP and retrieve input and test files
     ###############################################################################
     # Build COSP2 driver. Intel Fortran stores automatic arrays in the stack
-    # by default, whereas GNU Fortran stores them in the heap. This can cause 
+    # by default, whereas GNU Fortran stores them in the heap. This can cause
     # segmentation faults with ifort, especially in memory-intensive applications
     # like COSP. We tell ifort to use heap arrays.
     - name: Build driver
@@ -167,7 +192,7 @@ jobs:
         cd driver/data/outputs/UKMO
         md5sum -c cosp2_output.um_global.gfortran.kgo.nc.md5
     ###############################################################################
-    # Run COSP2 tests. We could run both tests in one step, but 
+    # Run COSP2 tests. We could run both tests in one step, but
     # doing it this way the output is easier to interpret.
     ###############################################################################
     # 1. Basic test
@@ -189,7 +214,7 @@ jobs:
     # 1. Basic test
     - name: Basic against known good output (KGO)
       run: |
-        source '/usr/share/miniconda/etc/profile.d/conda.sh' 
+        source '/usr/share/miniconda/etc/profile.d/conda.sh'
         conda activate
         if [[ -e /opt/intel/oneapi/setvars.sh ]]; then
           ATOL=1.0e-20
@@ -204,7 +229,7 @@ jobs:
     # and then we test against the output table.
     - name: UM global against known good output (KGO)
       run: |
-        source '/usr/share/miniconda/etc/profile.d/conda.sh' 
+        source '/usr/share/miniconda/etc/profile.d/conda.sh'
         conda activate
         cd driver
         KGO=data/outputs/UKMO/cosp2_output.um_global.gfortran.kgo.nc
@@ -227,7 +252,7 @@ jobs:
     - name: Produce plots and create tarball
       if: failure()
       run: |
-        source '/usr/share/miniconda/etc/profile.d/conda.sh' 
+        source '/usr/share/miniconda/etc/profile.d/conda.sh'
         conda activate
         cd driver
         if [[ -e data/outputs/UKMO/cosp2_output.um_global.nc ]]; then

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -146,7 +146,6 @@ jobs:
 
     # Cache netcdf FORTRAN library
     - name: cache-netcdf-fortran
-      if: False
       id: cache-netcdf-fortran
       uses: actions/cache@v2
       with:
@@ -164,7 +163,7 @@ jobs:
         git clone https://github.com/Unidata/netcdf-fortran.git --branch v4.4.4
         cd netcdf-fortran
         ./configure --prefix=${NFHOME}
-        make
+        make -j
         sudo make install
     ###############################################################################
     # Build COSP and retrieve input and test files
@@ -178,7 +177,7 @@ jobs:
         source /opt/intel/oneapi/setvars.sh || true
         ${F90} --version
         cd build
-        make driver
+        make -j driver
     # Retrieve and expand large data files
     - name: Retrieve data files
       run: |

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        fortran-compiler: [gfortran, gfortran-8, gfortran-9, ifort]
+        fortran-compiler: [ifort]
     env:
       F90: ${{ matrix.fortran-compiler }}
       FC: ${{ matrix.fortran-compiler }}
@@ -62,7 +62,7 @@ jobs:
       if: contains(matrix.fortran-compiler, 'gfortran')
       run: sudo apt-get install ${{ matrix.fortran-compiler }}
     # Intel compilers and libraries if needed
-    #   https://software.intel.com/content/www/us/en/develop/articles/oneapi-repo-instructions.html#aptpkg
+    # https://software.intel.com/content/www/us/en/develop/articles/installing-intel-oneapi-toolkits-via-apt.html
     - name: Install Intel compilers and libraries
       if: ${{ matrix.fortran-compiler == 'ifort' }}
       run: |
@@ -70,11 +70,8 @@ jobs:
         sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
         sudo add-apt-repository "deb https://apt.repos.intel.com/oneapi all main"
         sudo apt-get update
-        sudo apt-get install intel-oneapi-common-licensing
-        sudo apt-get install intel-oneapi-common-vars
-        sudo apt-get install intel-oneapi-dev-utilities
-        sudo apt-get install intel-oneapi-icc
-        sudo apt-get install intel-oneapi-ifort
+        sudo apt-get install intel-basekit
+        sudo apt-get install intel-hpckit
     # Nvidia compilers
     - name: Nvidia setup compilers
       env:
@@ -87,7 +84,7 @@ jobs:
     - name: Environment for ifort compiler
       if: ${{ matrix.fortran-compiler == 'ifort' }}
       run: |
-        echo "::set-env name=CC::icc"
+        echo "::set-env name=CC::icx"
         echo "::set-env name=FC::ifort"
         echo "::set-env name=F90FLAGS::-O3 -heap-arrays"
     - name: Environment for nvfortran compiler

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        fortran-compiler: [gfortran, gfortran-8, gfortran-9, nvfortran]
+        fortran-compiler: [nvfortran]
     env:
       F90: ${{ matrix.fortran-compiler }}
       FC: ${{ matrix.fortran-compiler }}

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -54,11 +54,15 @@ jobs:
     ###############################################################################
     # Set up Python and install dependencies
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
-        python-version: '3.x'
-    - name: Install python dependencies
-      run: conda install cartopy matplotlib netcdf4
+        python-version: 3.7
+    - name: Setup conda
+      uses: s-weigand/setup-conda@v1
+      with:
+        python-version: 3.7
+    - name: Install python packages
+      run: conda install --yes cartopy matplotlib netcdf4
     # Update system packages
     - name: Update system packages
       run: sudo apt-get update
@@ -214,8 +218,6 @@ jobs:
     # 1. Basic test
     - name: Basic against known good output (KGO)
       run: |
-        source '/usr/share/miniconda/etc/profile.d/conda.sh'
-        conda activate
         if [[ -e /opt/intel/oneapi/setvars.sh ]]; then
           ATOL=1.0e-20
           RTOL=0.0006
@@ -229,8 +231,6 @@ jobs:
     # and then we test against the output table.
     - name: UM global against known good output (KGO)
       run: |
-        source '/usr/share/miniconda/etc/profile.d/conda.sh'
-        conda activate
         cd driver
         KGO=data/outputs/UKMO/cosp2_output.um_global.gfortran.kgo.nc
         TST=data/outputs/UKMO/cosp2_output.um_global.nc
@@ -252,8 +252,6 @@ jobs:
     - name: Produce plots and create tarball
       if: failure()
       run: |
-        source '/usr/share/miniconda/etc/profile.d/conda.sh'
-        conda activate
         cd driver
         if [[ -e data/outputs/UKMO/cosp2_output.um_global.nc ]]; then
           python plot_test_outputs.py

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -126,7 +126,7 @@ jobs:
     - name: Build NetCDF FORTRAN library
       env:
         FCFLAGS: -fPIC
-      if: ${{ matrix.fortran-compiler != 'gfortran' }} && steps.cache-netcdf-fortran.outputs.cache-hit != 'true'
+      if: steps.cache-netcdf-fortran.outputs.cache-hit != 'true'
       run: |
         source /opt/intel/oneapi/setvars.sh || true
         ${F90} --version

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -88,7 +88,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: /opt/intel
-        key: intel-${{ runner.os }}-compilers
+        key: intel-${{ runner.os }}-compilers-a
 
     # https://software.intel.com/content/www/us/en/develop/articles/installing-intel-oneapi-toolkits-via-apt.html
     - name: Install Intel compilers and libraries

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        fortran-compiler: [gfortran, gfortran-8]
+        fortran-compiler: [gfortran]
     env:
       F90: ${{ matrix.fortran-compiler }}
       FC: ${{ matrix.fortran-compiler }}

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -36,13 +36,14 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        fortran-compiler: [gfortran, gfortran-8, gfortran-9]
+        fortran-compiler: [gfortran, gfortran-8]
     env:
       F90: ${{ matrix.fortran-compiler }}
       FC: ${{ matrix.fortran-compiler }}
       F90FLAGS: "-O3 -ffree-line-length-none -fcheck=bounds -finit-real=nan"
       ATOL: 0.0
       RTOL: 0.0
+      NFHOME: /home/runner/netcdf-fortran
     # Sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out repository under $GITHUB_WORKSPACE
@@ -120,7 +121,7 @@ jobs:
       id: cache-netcdf-fortran
       uses: actions/cache@v2
       with:
-        path: /home/runner/netcdf-fortran
+        path: ${NFHOME}
         key: netcdf-fortran-4.4.4-${{ runner.os }}-${{ matrix.fortran-compiler }}
     # Build NetCDF FORTRAN library for all compilers but gfortran
     - name: Build NetCDF FORTRAN library
@@ -132,7 +133,7 @@ jobs:
         ${F90} --version
         git clone https://github.com/Unidata/netcdf-fortran.git --branch v4.4.4
         cd netcdf-fortran
-        ./configure --prefix=/usr
+        ./configure --prefix=${NFHOME}
         make
         sudo make install
     ###############################################################################

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -99,8 +99,8 @@ jobs:
         sudo add-apt-repository "deb https://apt.repos.intel.com/oneapi all main"
         sudo apt-get update
         sudo -E apt-cache pkgnames intel | grep oneapi | sort | grep -v beta
-        sudo apt-get install intel-basekit
-        sudo apt-get install intel-hpckit
+        sudo apt-get install intel-hpckit-getting-started intel-oneapi-clck intel-oneapi-common-licensing intel-oneapi-common-vars
+        sudo apt-get install intel-oneapi-dev-utilities  intel-oneapi-dpcpp-cpp-compiler-pro intel-oneapi-ifort intel-oneapi-inspector intel-oneapi-itac
 
     #
     # Nvidia compilers

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -44,6 +44,7 @@ jobs:
       ATOL: 0.0
       RTOL: 0.0
       NFHOME: /home/runner/netcdf-fortran
+      LD_LIBRARY_PATH: ${NFHOME}/lib
     # Sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out repository under $GITHUB_WORKSPACE
@@ -174,8 +175,6 @@ jobs:
       run: |
         source /opt/intel/oneapi/setvars.sh || true
         cd driver/run
-        export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${NFHOME}/lib
-        echo ${LD_LIBRARY_PATH}
         ./cosp2_test cosp2_input_nl.txt
     # 2. UM global snapshot
     - name: UM global snapshot

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -150,7 +150,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: /home/runner/netcdf-fortran
-        key: netcdf-fortran-4.4.4-${{ runner.os }}-${{ matrix.fortran-compiler }}
+        key: netcdf-fortran-4.4.4a-${{ runner.os }}-${{ matrix.fortran-compiler }}
 
     # Build NetCDF FORTRAN library for current compiler
     - name: Build NetCDF FORTRAN library

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -92,8 +92,6 @@ jobs:
         sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
         sudo add-apt-repository "deb https://apt.repos.intel.com/oneapi all main"
         sudo apt-get update
-#        sudo apt-get install intel-basekit
-#        sudo apt-get install intel-hpckit
         sudo apt-get install intel-oneapi-common-licensing
         sudo apt-get install intel-oneapi-common-vars
         sudo apt-get install intel-oneapi-dev-utilities

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -118,7 +118,7 @@ jobs:
       run: sudo apt-get install libnetcdf-dev
     # Cache netcdf FORTRAN library
     - name: cache-netcdf-fortran
-      id: cache-netcdf-fortran
+      id: cache-netcdff
       uses: actions/cache@v2
       with:
         path: /home/runner/netcdf-fortran
@@ -127,7 +127,7 @@ jobs:
     - name: Build NetCDF FORTRAN library
       env:
         FCFLAGS: -fPIC
-      if: steps.cache-netcdf-fortran.outputs.cache-hit != 'true'
+      if: steps.cache-netcdff.outputs.cache-hit != 'true'
       run: |
         source /opt/intel/oneapi/setvars.sh || true
         ${F90} --version

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -86,6 +86,7 @@ jobs:
     # Environments for ifort and nvidia compilers
     - name: Environment for ifort compiler
       if: ${{ matrix.fortran-compiler == 'ifort' }}
+      run: |
         echo "::set-env name=CC::icc"
         echo "::set-env name=FC::ifort"
         echo "::set-env name=F90FLAGS::-O3 -heap-arrays"

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        fortran-compiler: [nvfortran]
+        fortran-compiler: [gfortran, gfortran-8, gfortran-9, ifort]
     env:
       F90: ${{ matrix.fortran-compiler }}
       FC: ${{ matrix.fortran-compiler }}

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        fortran-compiler: [gfortran, gfortran-8]
+        fortran-compiler: [gfortran, gfortran-8, gfortran-9]
     env:
       F90: ${{ matrix.fortran-compiler }}
       FC: ${{ matrix.fortran-compiler }}

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -97,7 +97,7 @@ jobs:
       run: |
         echo "::set-env name=CC::nvc"
         echo "::set-env name=FC::nvfortran"
-        echo "::set-env name=F90FLAGS::-Mallocatable=03 -Mstandard -Mbounds -Mchkptr -Kieee -Mchkstk"
+        echo "::set-env name=F90FLAGS::"
         echo "::add-path::${NVCOMPILERS}/Linux_x86_64/20.7/compilers/bin"
     # NetCDF C library
     - name: Install NetCDF library

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -138,7 +138,7 @@ jobs:
       run: |
         echo "::set-env name=CC::nvc"
         echo "::set-env name=FC::nvfortran"
-        echo "::set-env name=F90FLAGS::"
+        echo "::set-env name=F90FLAGS::-Mallocatable=03 -Mstandard -Mbounds -Mchkptr -Kieee -Mchkstk"
         echo "::add-path::${NVCOMPILERS}/Linux_x86_64/20.7/compilers/bin"
     ###############################################################################
     # NetCDF C and FORTRAN libraries

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -72,7 +72,9 @@ jobs:
     ###############################################################################
     # FORTRAN compilers
     ###############################################################################
+    #
     # Install gfortran compiler
+    #
     - name: Install gfortran compiler
       if: contains(matrix.fortran-compiler, 'gfortran')
       run: sudo apt-get install ${{ matrix.fortran-compiler }}

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -144,6 +144,7 @@ jobs:
 
     # Cache netcdf FORTRAN library
     - name: cache-netcdf-fortran
+      if: False
       id: cache-netcdf-fortran
       uses: actions/cache@v2
       with:

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -116,6 +116,13 @@ jobs:
     # NetCDF C library
     - name: Install NetCDF library
       run: sudo apt-get install libnetcdf-dev
+    # Cache netcdf FORTRAN library
+    - name: cache-netcdf-fortran
+      id: cache-netcdf-fortran
+      uses: actions/cache@v2.1.1
+      with:
+        path: /home/runner/netcdf-fortran
+        key: netcdf-fortran-4.4.4-${{ runner.os }}-${{ matrix.fortran-compiler }}
     # Build NetCDF FORTRAN library for all compilers
     - name: Build NetCDF FORTRAN library
       env:
@@ -129,13 +136,6 @@ jobs:
         ./configure --prefix=${NFHOME}
         make
         sudo make install
-    # Cache netcdf FORTRAN library
-    - name: cache-netcdf-fortran
-      id: cache-netcdf-fortran
-      uses: actions/cache@v2.1.1
-      with:
-        path: /home/runner/netcdf-fortran
-        key: netcdf-fortran-4.4.4-${{ runner.os }}-${{ matrix.fortran-compiler }}
     ###############################################################################
     # Build COSP and retrieve input and test files
     ###############################################################################

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -39,6 +39,7 @@ jobs:
         fortran-compiler: [gfortran, gfortran-8, gfortran-9, nvfortran]
     env:
       F90: ${{ matrix.fortran-compiler }}
+      FC: ${{ matrix.fortran-compiler }}
       F90FLAGS: "-O3 -ffree-line-length-none -fcheck=bounds -finit-real=nan"
       ATOL: 0.0
       RTOL: 0.0
@@ -82,15 +83,21 @@ jobs:
       run: |
         wget -q https://developer.download.nvidia.com/hpc-sdk/nvhpc-20-7_20.7_amd64.deb https://developer.download.nvidia.com/hpc-sdk/nvhpc-2020_20.7_amd64.deb
         sudo apt-get install ./nvhpc-20-7_20.7_amd64.deb ./nvhpc-2020_20.7_amd64.deb
-    - name: Nvidia environment
+    # Environments for ifort and nvidia compilers
+    - name: Environment for ifort compiler
+      if: ${{ matrix.fortran-compiler == 'ifort' }}
+        echo "::set-env name=CC::icc"
+        echo "::set-env name=FC::ifort"
+        echo "::set-env name=F90FLAGS::-O3 -heap-arrays"
+    - name: Environment for nvfortran compiler
       env:
         NVCOMPILERS: /opt/nvidia/hpc_sdk
       if: contains(matrix.fortran-compiler, 'nvfortran')
       run: |
-        echo "::set-env name=FC::nvfortran"
         echo "::set-env name=CC::nvc"
-        echo "::set-env name=FCFLAGS::-Mallocatable=03 -Mstandard -Mbounds -Mchkptr -Kieee -Mchkstk"
-        echo "::add-path::${NVCOMPILERS}/Linux_x86_64/20.7/compilers/bin"    # Install NetCDF library
+        echo "::set-env name=FC::nvfortran"
+        echo "::set-env name=F90FLAGS::-Mallocatable=03 -Mstandard -Mbounds -Mchkptr -Kieee -Mchkstk"
+        echo "::add-path::${NVCOMPILERS}/Linux_x86_64/20.7/compilers/bin"
     # NetCDF C library
     - name: Install NetCDF library
       run: sudo apt-get install libnetcdf-dev
@@ -107,11 +114,7 @@ jobs:
         ${F90} --version
         git clone https://github.com/Unidata/netcdf-fortran.git --branch v4.4.4
         cd netcdf-fortran
-        if [ -f /opt/intel/oneapi/setvars.sh ]; then
-          ./configure --prefix=/usr CC=icc
-        else
-          ./configure --prefix=/usr
-        fi        
+        ./configure --prefix=/usr
         make
         sudo make install
     # Build COSP2 driver. Intel Fortran stores automatic arrays in the stack
@@ -121,10 +124,7 @@ jobs:
     - name: Build driver
       run: |
         source /opt/intel/oneapi/setvars.sh || true
-        if [ -f /opt/intel/oneapi/setvars.sh ]; then
-          ${F90} --version
-          export F90FLAGS="-O3 -heap-arrays"
-        fi
+        ${F90} --version
         cd build
         make driver
     # Retrieve and expand large data files

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -115,6 +115,7 @@ jobs:
       run: sudo apt-get install libnetcdf-dev
     # Cache netcdf FORTRAN library
     - name: cache-netcdf-fortran
+      if: False
       id: cache-netcdf-fortran
       uses: actions/cache@v2
       with:

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -92,6 +92,7 @@ jobs:
         sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
         sudo add-apt-repository "deb https://apt.repos.intel.com/oneapi all main"
         sudo apt-get update
+        sudo -E apt-cache pkgnames intel | grep oneapi | sort | grep -v beta 
         sudo apt-get install intel-oneapi-common-licensing
         sudo apt-get install intel-oneapi-common-vars
         sudo apt-get install intel-oneapi-dev-utilities
@@ -123,7 +124,7 @@ jobs:
     - name: Environment for ifort compiler
       if: contains(matrix.fortran-compiler, 'ifort')
       run: |
-        echo "::set-env name=CC::icc"
+        echo "::set-env name=CC::icx"
         echo "::set-env name=FC::ifort"
         echo "::set-env name=F90FLAGS::-O3 -heap-arrays"
     - name: Environment for nvfortran compiler

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -113,10 +113,6 @@ jobs:
     # NetCDF C library
     - name: Install NetCDF library
       run: sudo apt-get install libnetcdf-dev
-    # NetCDF FORTRAN library from package repository
-    - name: Install NetCDF FORTRAN library for standard gfortran
-      if: ${{ matrix.fortran-compiler == 'gfortran' }}
-      run: sudo apt-get install libnetcdff-dev
     # Cache netcdf FORTRAN library
     - name: cache-netcdf-fortran
       id: cache-netcdf-fortran
@@ -124,7 +120,7 @@ jobs:
       with:
         path: ${NFHOME}
         key: netcdf-fortran-4.4.4-${{ runner.os }}-${{ matrix.fortran-compiler }}
-    # Build NetCDF FORTRAN library for all compilers but gfortran
+    # Build NetCDF FORTRAN library for all compilers
     - name: Build NetCDF FORTRAN library
       env:
         FCFLAGS: -fPIC

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -53,9 +53,12 @@ jobs:
         python-version: '3.x'
     - name: Install python dependencies
       run: conda install cartopy matplotlib netcdf4
-    # Install FORTRAN compiler
-    - name: Install gfortran compiler and NetCDF
-      if: ${{ matrix.fortran-compiler != 'ifort' }}
+    # Update system packages
+    - name: Update system packages
+      run: sudo apt-get update
+    # Install gfortran compiler
+    - name: Install gfortran compiler
+      if: contains(matrix.fortran-compiler, 'gfortran')
       run: sudo apt-get install ${{ matrix.fortran-compiler }}
     # Intel compilers and libraries if needed
     #   https://software.intel.com/content/www/us/en/develop/articles/oneapi-repo-instructions.html#aptpkg
@@ -90,9 +93,7 @@ jobs:
         echo "::add-path::${NVCOMPILERS}/Linux_x86_64/20.7/compilers/bin"    # Install NetCDF library
     # NetCDF C library
     - name: Install NetCDF library
-      run: |
-        sudo apt-get update
-        sudo apt-get install libnetcdf-dev
+      run: sudo apt-get install libnetcdf-dev
     # NetCDF FORTRAN library
     - name: Install NetCDF FORTRAN library for standard gfortran
       if: ${{ matrix.fortran-compiler == 'gfortran' }}

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -174,6 +174,7 @@ jobs:
       run: |
         source /opt/intel/oneapi/setvars.sh || true
         cd driver/run
+        export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${NFHOME}/lib
         echo ${LD_LIBRARY_PATH}
         ./cosp2_test cosp2_input_nl.txt
     # 2. UM global snapshot

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -92,12 +92,9 @@ jobs:
         sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
         sudo add-apt-repository "deb https://apt.repos.intel.com/oneapi all main"
         sudo apt-get update
-        sudo -E apt-cache pkgnames intel | grep oneapi | sort | grep -v beta 
-        sudo apt-get install intel-oneapi-common-licensing
-        sudo apt-get install intel-oneapi-common-vars
-        sudo apt-get install intel-oneapi-dev-utilities
-        sudo apt-get install intel-oneapi-icc
-        sudo apt-get install intel-oneapi-ifort
+        sudo -E apt-cache pkgnames intel | grep oneapi | sort | grep -v beta
+        sudo apt-get install intel-basekit
+        sudo apt-get install intel-hpckit
 
     #
     # Nvidia compilers

--- a/build/Makefile.conf
+++ b/build/Makefile.conf
@@ -1,6 +1,6 @@
 #F90      = gfortran
 #F90FLAGS = -O3 -ffree-line-length-none -fcheck=bounds -finit-real=nan
 
-F90_LIB     = /usr
+F90_LIB     = /home/runner/netcdf-fortran
 NC_INC      = -I$(F90_LIB)/include
 NC_LIB      = -L$(F90_LIB)/lib


### PR DESCRIPTION
The Intel oneAPI (ifort) is still evolving rapidly, so our CI test breaks when they release a new beta version. Here we upgrade to Beta09. 
This change also implements support for Nvidia compiler (nvfortran), but the COSP driver fails at runtime with an out of bounds error. It all points to a compiler bug, so for the moment nvfortran is not enabled.
