### PR TITLE
Consistent use of hgt_matrix_half. Delete delz in warm rain diagnostics.

### DIFF
--- a/driver/src/cosp2_test.f90
+++ b/driver/src/cosp2_test.f90
@@ -483,7 +483,6 @@ program cosp2_test
      cospstateIN%phalf(:,1)           = 0._wp
      ! Height at interface (nlevels+1). Set lowermost interface to 0.
      cospstateIN%hgt_matrix_half(:,1:Nlevels) = zlev_half(start_idx:end_idx,Nlevels:1:-1) ! km
-     cospstateIN%hgt_matrix_half(:,Nlevels+1) = 0._wp
      
      !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
      ! Generate subcolumns and compute optical inputs.
@@ -1011,7 +1010,7 @@ contains
              y%v_sfc(npoints),y%lat(npoints),y%lon(nPoints),y%emis_sfc(nchan),           &
              y%cloudIce(nPoints,nLevels),y%cloudLiq(nPoints,nLevels),y%surfelev(npoints),&
              y%fl_snow(nPoints,nLevels),y%fl_rain(nPoints,nLevels),y%seaice(npoints),    &
-             y%tca(nPoints,nLevels),y%hgt_matrix_half(npoints,nlevels+1))
+             y%tca(nPoints,nLevels),y%hgt_matrix_half(npoints,nlevels))
 
   end subroutine construct_cospstateIN
 

--- a/driver/src/cosp2_test.f90
+++ b/driver/src/cosp2_test.f90
@@ -481,7 +481,9 @@ program cosp2_test
      ! Pressure at interface (nlevels+1). Set uppermost interface to 0.
      cospstateIN%phalf(:,2:Nlevels+1) = ph(start_idx:end_idx,Nlevels:1:-1)   ! Pa  
      cospstateIN%phalf(:,1)           = 0._wp
-     ! Height at interface (nlevels+1). Set lowermost interface to 0.
+     ! Height of bottom interfaces of model layers (nlevels).
+     ! cospstateIN%hgt_matrix_half(:,1) contains the bottom of the top layer.
+     ! cospstateIN%hgt_matrix_half(:,Nlevels) contains the bottom of the surface layer.
      cospstateIN%hgt_matrix_half(:,1:Nlevels) = zlev_half(start_idx:end_idx,Nlevels:1:-1) ! km
      
      !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/src/cosp.F90
+++ b/src/cosp.F90
@@ -735,7 +735,7 @@ CONTAINS
        rttovIN%n2o        => cospgridIN%n2o
        rttovIN%co         => cospgridIN%co
        rttovIN%surfem     => cospgridIN%emis_sfc
-       rttovIN%h_surf     => cospgridIN%hgt_matrix_half(:,cospIN%Nlevels+1)
+       rttovIN%h_surf     => cospgridIN%hgt_matrix_half(:,cospIN%Nlevels)
        rttovIN%u_surf     => cospgridIN%u_sfc
        rttovIN%v_surf     => cospgridIN%v_sfc
        rttovIN%t_skin     => cospgridIN%skt
@@ -1655,16 +1655,9 @@ CONTAINS
           deallocate( zlev, delz, t_in, tempI, frac_outI, Ze_totI )
        else  ! do not use vgrid interporation ---------------------------------------!
           !! original model grid
-          allocate( delz(cloudsatIN%Npoints,cospIN%Nlevels) )
-          do k = 1, cospIN%Nlevels-1
-             delz(:,k) = cospgridIN%hgt_matrix_half(:,k+1) &
-                         - cospgridIN%hgt_matrix_half(:,k)
-          enddo
-          delz(:,cospIN%Nlevels) = 2.0*( cospgridIN%hgt_matrix(:,cospIN%Nlevels) &
-                                  - cospgridIN%hgt_matrix_half(:,cospIN%Nlevels) )
           call cosp_diag_warmrain(                                            &
                cloudsatIN%Npoints, cloudsatIN%Ncolumns, cospIN%Nlevels,       & !! in
-               cospgridIN%at, cospgridIN%hgt_matrix, delz,                    & !! in
+               cospgridIN%at, cospgridIN%hgt_matrix,                          & !! in
                cospOUT%modis_Liquid_Water_Path_Mean,                          & !! in
                cospOUT%modis_Optical_Thickness_Water_Mean,                    & !! in
                cospOUT%modis_Cloud_Particle_Size_Water_Mean,                  & !! in
@@ -1676,7 +1669,6 @@ CONTAINS
                cospIN%frac_out,                                               & !! in
                cloudsatDBZe,                                                  & !! in
                cfodd_ntotal, wr_occfreq_ntotal                                ) !! inout
-          deallocate( delz )
        endif  !! use_vgrid or not
 
        ! Store, when necessary
@@ -3808,7 +3800,7 @@ CONTAINS
        if (size(cospgridIN%pfull,2)           .ne. cospIN%Nlevels   .OR. &
            size(cospgridIN%at,2)              .ne. cospIN%Nlevels   .OR. &
            size(cospgridIN%qv,2)              .ne. cospIN%Nlevels   .OR. &
-           size(cospgridIN%hgt_matrix_half,2) .ne. cospIN%Nlevels+1 .OR. &
+           size(cospgridIN%hgt_matrix_half,2) .ne. cospIN%Nlevels   .OR. &
            size(cospgridIN%phalf,2)           .ne. cospIN%Nlevels+1 .OR. &
            size(cospgridIN%qv,2)              .ne. cospIN%Nlevels) then
           Lrttov_column    = .false.

--- a/src/cosp.F90
+++ b/src/cosp.F90
@@ -388,7 +388,6 @@ CONTAINS
          t_in,tempI,frac_outI      ! subscript "I": vertical interpolation (use_vgrid=.true.)
     real(wp), allocatable ::     &
          zlev   (:,:),           & ! altitude (used only when use_vgrid=.true.)
-         delz   (:,:),           & ! delta Z
          cfodd_ntotal (:,:,:,:), & ! # of total samples for CFODD (Npoints,CFODD_NDBZE,CFODD_NICOD,CFODD_NCLASS)
          wr_occfreq_ntotal(:,:)    ! # of warm-rain (nonprecip/drizzle/precip) (Npoints,WR_NREGIME)
 
@@ -1607,14 +1606,12 @@ CONTAINS
        if ( use_vgrid ) then
           !! interporation for fixed vertical grid:
           allocate( zlev(cloudsatIN%Npoints,Nlvgrid),                         &
-                    delz(cloudsatIN%Npoints,Nlvgrid),                         &
                     t_in(cloudsatIN%Npoints,1,cloudsatIN%Nlevels),            &
                     tempI(cloudsatIN%Npoints,1,Nlvgrid),                      &
                     Ze_totI(cloudsatIN%Npoints,cloudsatIN%Ncolumns,Nlvgrid),  &
                     frac_outI(cloudsatIN%Npoints,cloudsatIN%Ncolumns,Nlvgrid) )
           do k = 1, Nlvgrid
              zlev(:,k) = vgrid_zu(k)
-             delz(:,k) = dz(k)
           enddo
           t_in(:,1,:) = cospgridIN%at(:,:)
           call cosp_change_vertical_grid (                                    &
@@ -1640,7 +1637,7 @@ CONTAINS
                frac_outI(:,:,Nlvgrid:1:-1)                                    )
           call cosp_diag_warmrain(                                            &
                cloudsatIN%Npoints, cloudsatIN%Ncolumns, Nlvgrid,              & !! in
-               tempI, zlev, delz,                                             & !! in
+               tempI, zlev,                                                   & !! in
                cospOUT%modis_Liquid_Water_Path_Mean,                          & !! in
                cospOUT%modis_Optical_Thickness_Water_Mean,                    & !! in
                cospOUT%modis_Cloud_Particle_Size_Water_Mean,                  & !! in
@@ -1652,7 +1649,7 @@ CONTAINS
                frac_outI,                                                     & !! in
                Ze_totI,                                                       & !! in
                cfodd_ntotal, wr_occfreq_ntotal                                ) !! inout
-          deallocate( zlev, delz, t_in, tempI, frac_outI, Ze_totI )
+          deallocate( zlev, t_in, tempI, frac_outI, Ze_totI )
        else  ! do not use vgrid interporation ---------------------------------------!
           !! original model grid
           call cosp_diag_warmrain(                                            &

--- a/src/cosp.F90
+++ b/src/cosp.F90
@@ -90,8 +90,10 @@ MODULE MOD_COSP
           pfull,               & ! Pressure                               (Pa)
           phalf,               & ! Pressure at half-levels                (Pa)
           qv,                  & ! Specific humidity                      (kg/kg)
-          hgt_matrix,          & ! Height of hydrometeors                 (km)
-          hgt_matrix_half        ! Height of hydrometeors at half levels  (km)
+          hgt_matrix,          & ! Height of atmosphere layer             (km)
+          hgt_matrix_half        ! Height of bottom interface of atm layer(km)
+                                 ! First level contains the bottom of the top layer.
+                                 ! Last level contains the bottom of the surface layer.
 
      real(wp),allocatable,dimension(:) :: &
           land,                & ! Land/Sea mask                          (0-1)

--- a/src/cosp_stats.F90
+++ b/src/cosp_stats.F90
@@ -283,7 +283,7 @@ END SUBROUTINE COSP_CHANGE_VERTICAL_GRID
   !               E-mail: michibata@riam.kyushu-u.ac.jp
   !%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
   SUBROUTINE COSP_DIAG_WARMRAIN( Npoints, Ncolumns, Nlevels,           & !! in
-                                 temp,    zlev,     delz,              & !! in
+                                 temp,    zlev,                        & !! in
                                  lwp,     liqcot,   liqreff, liqcfrc,  & !! in
                                  iwp,     icecot,   icereff, icecfrc,  & !! in
                                  fracout, dbze,                        & !! in
@@ -306,8 +306,7 @@ END SUBROUTINE COSP_CHANGE_VERTICAL_GRID
          icereff,          & ! MODIS ice Reff [m]
          icecfrc             ! MODIS ice cloud fraction
     real(wp), dimension(Npoints,Nlevels), intent(in) :: &
-         zlev,             & ! altitude [m] for model level
-         delz                ! delta Z [m] (= zlevm(k+1)-zlemv(k))
+         zlev                ! altitude [m] for model level
     real(wp), dimension(Npoints,1,Nlevels),intent(in) :: &
          temp                ! temperature [K]
     real(wp), dimension(Npoints,Ncolumns,Nlevels),intent(in) :: &

--- a/src/simulator/actsim/lidar_simulator.F90
+++ b/src/simulator/actsim/lidar_simulator.F90
@@ -301,7 +301,7 @@ contains
          ok_lidar_cfad ! True if lidar CFAD diagnostics need to be computed
     real(wp),intent(in),dimension(npoints,nlevels) :: &
          zlev        ! Model full levels
-    real(wp),intent(in),dimension(npoints,nlevels+1) :: &
+    real(wp),intent(in),dimension(npoints,nlevels) :: &
          zlev_half   ! Model half levels
     real(wp),intent(in),dimension(llm) :: & 
          vgrid_z     ! mid-level altitude of the output vertical grid

--- a/src/simulator/quickbeam/quickbeam.F90
+++ b/src/simulator/quickbeam/quickbeam.F90
@@ -255,7 +255,7 @@ contains
          Ze_tot_non    ! Effective reflectivity factor w/o attenuation (dBZ)
     real(wp),intent(in),dimension(npoints,Nlevels) :: &
          zlev          ! Model full levels
-    real(wp),intent(in),dimension(npoints,Nlevels+1) :: &
+    real(wp),intent(in),dimension(npoints,Nlevels) :: &
          zlev_half     ! Model half levels
          
     ! Outputs


### PR DESCRIPTION
This pull request addresses #60 and deletes variable delz, which was not used by the warm rain diagnostics.