### PR TITLE
Replace goto with a loop exit

### DIFF
--- a/src/simulator/actsim/lidar_simulator.F90
+++ b/src/simulator/actsim/lidar_simulator.F90
@@ -967,7 +967,8 @@ contains
                 ! Find the level of the highest cloud with SR>30
                 if(x(i,ncol,nlev) .gt. S_cld_att) then ! SR > 30.
                     toplvlsat = nlev+1
-                    goto 99
+                    !goto 99
+                    exit ! nlev altitude loop
                 endif
              endif ! end of cloud condition
           enddo ! end of altitude loop


### PR DESCRIPTION
When building E3SM with IBM module `xl/16.1.1-9` on Summit, compiler issues a build error
```
"/autofs/nccs-svm1_home1/azamat/repos/E3SM/components/eam/src/physics/cosp2/external/src/simulator/actsim/lidar_simulator.F90", line 970.20: 1511-122 (E) Unconditional GO TO statement refers to statement inside a DO-loop, IF block, CASE construct, SELECT TYPE construct, ASSOCIATE construct, WHERE construct or FORALL construct with label 99.  Transfer of control into a DO-loop, IF block, CASE construct, SELECT TYPE construct, ASSOCIATE construct, WHERE construct or FORALL construct is not permitted.
** mod_lidar_simulator   === End of Compilation 1 ===
1501-511  Compilation failed for file lidar_simulator.F90.
Target CMakeFiles/atm.dir/__/__/eam/src/physics/cosp2/external/src/simulator/actsim/lidar_simulator.F90.o built in 0.167706 seconds
gmake[2]: *** [cmake/atm/CMakeFiles/atm.dir/__/__/eam/src/physics/cosp2/external/src/simulator/actsim/lidar_simulator.F90.o] Error 1
```

This is a one-line update replacing a `goto` statement with a loop `exit` statement to address the error.
Checked with an E3SM testcase `SMS_D_Ln5.ne4_ne4.FC5AV1C-L.summit_ibm.eam-cosplite_nhtfrq5`