### PR TITLE
Add error checking for surface-elevation input field (surfelev).

### DIFF
--- a/src/cosp.F90
+++ b/src/cosp.F90
@@ -2192,6 +2192,11 @@ CONTAINS
           errorMessage(nError) = 'ERROR: COSP input variable (Calipso Lidar simulator): cospgridIN%at has not been allocated'
           alloc_status = .false.
        endif
+       if (.not. allocated(cospgridIN%surfelev)) then
+          nError=nError+1
+          errorMessage(nError) = 'ERROR: COSP input variable (Calipso Lidar simulator): cospgridIN%surfelev has not been allocated'
+          alloc_status = .false.
+       endif
        if (.not. allocated(cospgridIN%phalf)) then
           nError=nError+1
           errorMessage(nError) = 'ERROR: COSP input variable (Calipso Lidar simulator): cospgridIN%phalf has not been allocated'
@@ -2283,6 +2288,12 @@ CONTAINS
           nError=nError+1
           errorMessage(nError) = 'ERROR: COSP input variable (Cloudsat radar simulator):'//&
                ' cospgridIN%hgt_matrix has not been allocated'
+          alloc_status = .false.
+       endif
+       if (.not. allocated(cospgridIN%surfelev)) then
+          nError=nError+1
+          errorMessage(nError) = 'ERROR: COSP input variable (Cloudsat radar simulator):'//&
+               ' cospgridIN%surfelev has not been allocated'
           alloc_status = .false.
        endif
        if (.not. alloc_status) then


### PR DESCRIPTION
This PR addresses the issues in https://github.com/CFMIP/COSPv2.0/issues/27.
It expands the routine cosp_errorCheck, which checks to ensure that all of the required input fields are allocated for the requested diagnostics.
There are no changes to the KGO.