### PR TITLE
Bugfix in treatment of non-sunlit columns in warm rain diagnostics

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -43,7 +43,7 @@ jobs:
       F90FLAGS: "-O3 -ffree-line-length-none -fcheck=bounds -finit-real=nan"
       ATOL: 0.0
       RTOL: 0.0
-      KGO_VERSION: v001
+      KGO_VERSION: v002
       NFHOME: /home/runner/netcdf-fortran
       LD_LIBRARY_PATH: /home/runner/netcdf-fortran/lib
     # Sequence of tasks that will be executed as part of the job
@@ -184,21 +184,21 @@ jobs:
     # Retrieve and expand large data files
     - name: Retrieve data files
       run: |
-        GDFILE='https://docs.google.com/uc?export=download&id=17eK4_DVEvFOE9Uf6siXJDpWZJKT1aqkU'
+        GDFILE='https://docs.google.com/uc?export=download&id=1s5Ha6Hqnv_hWbRUs8KQpJ4Lxy8uvJDar'
         OUTPATH=driver/data/inputs/UKMO/cosp_input.um_global.nc.gz
         wget --no-check-certificate $GDFILE -O $OUTPATH
         gunzip ${OUTPATH}
         cd driver/data/inputs/UKMO
         md5sum -c cosp_input.um_global.nc.md5
         cd ${GITHUB_WORKSPACE}
-        GDFILE='https://docs.google.com/uc?export=download&id=1uQBPUEXlniQWEp2nU3iC6d8CO3GM9cvP'
+        GDFILE='https://docs.google.com/uc?export=download&id=11dKcIL3EQr7s6jbo4f9GsoW0SufesGbq'
         OUTPATH=driver/data/outputs/UKMO/cosp2_output.um_global.gfortran.kgo.$KGO_VERSION.nc.gz
         wget --no-check-certificate $GDFILE -O $OUTPATH
         gunzip ${OUTPATH}
         cd driver/data/outputs/UKMO
         md5sum -c cosp2_output.um_global.gfortran.kgo.$KGO_VERSION.nc.md5
         cd ${GITHUB_WORKSPACE}
-        GDFILE='https://docs.google.com/uc?export=download&id=1gSEdJJpqhfElsFNcTF_r4A_0vIMEWGla'
+        GDFILE='https://docs.google.com/uc?export=download&id=1kY1lRgzd0UhDiQef2u-VgTQql_iut3U2'
         OUTPATH=driver/data/outputs/UKMO/cosp2_output_um.gfortran.kgo.$KGO_VERSION.nc.gz
         wget --no-check-certificate $GDFILE -O $OUTPATH
         gunzip ${OUTPATH}

--- a/driver/data/outputs/UKMO/cosp2_output.um_global.gfortran.kgo.v002.nc.md5
+++ b/driver/data/outputs/UKMO/cosp2_output.um_global.gfortran.kgo.v002.nc.md5
@@ -1,0 +1,1 @@
+8a92ffdfbfd57be097180c0779d4a615  cosp2_output.um_global.gfortran.kgo.v002.nc

--- a/driver/data/outputs/UKMO/cosp2_output.um_global_model_levels.gfortran.kgo.v002.nc.md5
+++ b/driver/data/outputs/UKMO/cosp2_output.um_global_model_levels.gfortran.kgo.v002.nc.md5
@@ -1,0 +1,1 @@
+0acb75118bd8a79cd994618da6469fe0  cosp2_output.um_global_model_levels.gfortran.kgo.v002.nc

--- a/driver/data/outputs/UKMO/cosp2_output_um.gfortran.kgo.v002.nc.md5
+++ b/driver/data/outputs/UKMO/cosp2_output_um.gfortran.kgo.v002.nc.md5
@@ -1,0 +1,1 @@
+85b6de33a01014740788847d4f29f49e  cosp2_output_um.gfortran.kgo.v002.nc


### PR DESCRIPTION
The warm rain diagnostics did intend to use only daytime cloudy scenes, but actually the current code did not explicitly exclude dark-scene columns from the analysis.
To fix this bug, this pull request modifies the treatment of dark-scene columns as suggested by @brhillman and @dustinswales at the previous PR from 2019 (#36).