### PR TITLE
Lfric warnings wp

### DIFF
--- a/src/cosp_stats.F90
+++ b/src/cosp_stats.F90
@@ -326,7 +326,7 @@ END SUBROUTINE COSP_CHANGE_VERTICAL_GRID
     integer  :: kctop, kcbtm
     integer  :: icls
     integer  :: iregime
-    real     :: cmxdbz
+    real(wp) :: cmxdbz
     real(wp) :: diagcgt   !! diagnosed cloud geometric thickness [m]
     real(wp) :: diagicod  !! diagnosed in-cloud optical depth
     real(wp) :: cbtmh     !! diagnosed in-cloud optical depth

--- a/src/simulator/parasol/parasol.F90
+++ b/src/simulator/parasol/parasol.F90
@@ -168,8 +168,8 @@ contains
        parasolrefl(:,k) = parasolrefl(:,k) / float(ncol)
        ! if land=1 -> parasolrefl=R_UNDEF
        ! if land=0 -> parasolrefl=parasolrefl
-       parasolrefl(:,k) = parasolrefl(:,k) * MAX(1._wp-land(:),0.0) &
-            + (1._wp - MAX(1._wp-land(:),0.0))*R_UNDEF
+       parasolrefl(:,k) = parasolrefl(:,k) * MAX(1._wp-land(:),0.0_wp) &
+            + (1._wp - MAX(1._wp-land(:),0.0_wp))*R_UNDEF
     enddo
   end subroutine parasol_column
 


### PR DESCRIPTION
lfric builds do not specify the Fortran standard to which the program is expected to conform. Unfortunately, not setting a -stand or -std flag in builds has allowed some non-standard code to make its way onto the socrates trunk. This PR fixes a couple of wp missing.