### PR TITLE
Correct indexing of cospOUT 

### DIFF
--- a/src/cosp.F90
+++ b/src/cosp.F90
@@ -1273,8 +1273,8 @@ CONTAINS
             Nlvgrid, cloudsat_DBZE_BINS, 'cloudsat', cloudsatDBZe, cloudsatZe_non,       &
             cospgridIN%land(:), cospgridIN%surfelev(:), cospgridIN%at(:,cospIN%Nlevels), &
             cospIN%fracPrecipIce, cospgridIN%hgt_matrix, cospgridIN%hgt_matrix_half,     &
-            cospOUT%cloudsat_cfad_ze(ij:ik,:,:), cospOUT%cloudsat_precip_cover,          &
-            cospOUT%cloudsat_pia)
+            cospOUT%cloudsat_cfad_ze(ij:ik,:,:), cospOUT%cloudsat_precip_cover(ij:ik,:), &
+            cospOUT%cloudsat_pia(ij:ik))
        ! Free up memory  (if necessary)
        if (allocated(out1D_1)) then
           deallocate(out1D_1)
@@ -1640,14 +1640,14 @@ CONTAINS
           call cosp_diag_warmrain(                                            &
                cloudsatIN%Npoints, cloudsatIN%Ncolumns, Nlvgrid,              & !! in
                tempI, zlev,                                                   & !! in
-               cospOUT%modis_Liquid_Water_Path_Mean,                          & !! in
-               cospOUT%modis_Optical_Thickness_Water_Mean,                    & !! in
-               cospOUT%modis_Cloud_Particle_Size_Water_Mean,                  & !! in
-               cospOUT%modis_Cloud_Fraction_Water_Mean,                       & !! in
-               cospOUT%modis_Ice_Water_Path_Mean,                             & !! in
-               cospOUT%modis_Optical_Thickness_Ice_Mean,                      & !! in
-               cospOUT%modis_Cloud_Particle_Size_Ice_Mean,                    & !! in
-               cospOUT%modis_Cloud_Fraction_Ice_Mean,                         & !! in
+               cospOUT%modis_Liquid_Water_Path_Mean(ij:ik),                   & !! in
+               cospOUT%modis_Optical_Thickness_Water_Mean(ij:ik),             & !! in
+               cospOUT%modis_Cloud_Particle_Size_Water_Mean(ij:ik),           & !! in
+               cospOUT%modis_Cloud_Fraction_Water_Mean(ij:ik),                & !! in
+               cospOUT%modis_Ice_Water_Path_Mean(ij:ik),                      & !! in
+               cospOUT%modis_Optical_Thickness_Ice_Mean(ij:ik),               & !! in
+               cospOUT%modis_Cloud_Particle_Size_Ice_Mean(ij:ik),             & !! in
+               cospOUT%modis_Cloud_Fraction_Ice_Mean(ij:ik),                  & !! in
                frac_outI,                                                     & !! in
                Ze_totI,                                                       & !! in
                cfodd_ntotal, wr_occfreq_ntotal                                ) !! inout
@@ -1657,14 +1657,14 @@ CONTAINS
           call cosp_diag_warmrain(                                            &
                cloudsatIN%Npoints, cloudsatIN%Ncolumns, cospIN%Nlevels,       & !! in
                cospgridIN%at, cospgridIN%hgt_matrix,                          & !! in
-               cospOUT%modis_Liquid_Water_Path_Mean,                          & !! in
-               cospOUT%modis_Optical_Thickness_Water_Mean,                    & !! in
-               cospOUT%modis_Cloud_Particle_Size_Water_Mean,                  & !! in
-               cospOUT%modis_Cloud_Fraction_Water_Mean,                       & !! in
-               cospOUT%modis_Ice_Water_Path_Mean,                             & !! in
-               cospOUT%modis_Optical_Thickness_Ice_Mean,                      & !! in
-               cospOUT%modis_Cloud_Particle_Size_Ice_Mean,                    & !! in
-               cospOUT%modis_Cloud_Fraction_Ice_Mean,                         & !! in
+               cospOUT%modis_Liquid_Water_Path_Mean(ij:ik),                   & !! in
+               cospOUT%modis_Optical_Thickness_Water_Mean(ij:ik),             & !! in
+               cospOUT%modis_Cloud_Particle_Size_Water_Mean(ij:ik),           & !! in
+               cospOUT%modis_Cloud_Fraction_Water_Mean(ij:ik),                & !! in
+               cospOUT%modis_Ice_Water_Path_Mean(ij:ik),                      & !! in
+               cospOUT%modis_Optical_Thickness_Ice_Mean(ij:ik),               & !! in
+               cospOUT%modis_Cloud_Particle_Size_Ice_Mean(ij:ik),             & !! in
+               cospOUT%modis_Cloud_Fraction_Ice_Mean(ij:ik),                  & !! in
                cospIN%frac_out,                                               & !! in
                cloudsatDBZe,                                                  & !! in
                cfodd_ntotal, wr_occfreq_ntotal                                ) !! inout


### PR DESCRIPTION
Hi all,

The cospOUT DDT seems to be missing correct indexing for when inputs are chunked in the CloudSat quickbeam_column call (lines 1272-1277) and the cosp_diag_warmrain call (lines 1640-1670). I have corrected the indexing errors. 

@dustinswales mentioned that there might be an issue in how the MODIS diagnostics are passed to the warm rain diagnostics. I think that adding the (ij:ik) indexing when passing cospOUT fields to cosp_diag_warm as inputs should align the other warm rain diagnostic inputs with cospOUT and fix things.

A simple test using the COSP offline driver showed changes relative to the KGO values when chunking is used. This is expected. There should be no changes when there is no chunking in calls to COSP_SIMULATOR.

Best,
Jonah