### PR TITLE
Split CI workflows into gfortran and containerized

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "master"

--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -7,21 +7,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        compiler: [ifort]
+        compiler: [ifx]
         include:
         # Set flags for Intel Fortran Compiler Classic
-        - compiler: ifort
-          fcflags: -m64 -g -traceback -heap-arrays -assume realloc_lhs -extend-source 132 -check bounds,uninit,pointers,stack -stand f08
+        # - compiler: ifort
+        #   fcflags: -m64 -g -traceback -heap-arrays -assume realloc_lhs -extend-source 132 -check bounds,uninit,pointers,stack -stand f08
+        #   gdkgo1: https://docs.google.com/uc?export=download&id=1TpXY-vXkwAnym9nNjzUxt1q_8c8T7X8T
+        #   gdkgo2: https://docs.google.com/uc?export=download&id=1ic-2B3dIx1kIoi-Nd1ndLbLAe_LIWDGP
+        # Set flags for Intel Fortran Compiler
+        - compiler: ifx
+          fcflags: -debug -traceback -O0 -heap-arrays -assume realloc_lhs -extend-source 132 -stand f08
           gdkgo1: https://docs.google.com/uc?export=download&id=1TpXY-vXkwAnym9nNjzUxt1q_8c8T7X8T
           gdkgo2: https://docs.google.com/uc?export=download&id=1ic-2B3dIx1kIoi-Nd1ndLbLAe_LIWDGP
-        # # Set flags for Intel Fortran Compiler
-        # - compiler: ifx
-        #   fcflags: -debug -traceback -O0 -heap-arrays -assume realloc_lhs -extend-source 132 -stand f08
         # Set container images
-        - compiler: ifort
-          image: ghcr.io/earth-system-radiation/rte-rrtmgp-ci:oneapi
-        # - compiler: ifx
+        # - compiler: ifort
         #   image: ghcr.io/earth-system-radiation/rte-rrtmgp-ci:oneapi
+        - compiler: ifx
+          image: ghcr.io/earth-system-radiation/rte-rrtmgp-ci:oneapi
     container:
       image: ${{ matrix.image }}
     env:
@@ -98,22 +100,13 @@ jobs:
         KGO=data/outputs/UKMO/cosp2_output_um.${F90}.kgo.$KGO_VERSION.nc
         TST=data/outputs/UKMO/cosp2_output_um.nc
         python compare_to_kgo.py ${KGO} ${TST} --atol=${ATOL} --rtol=${RTOL}
-    # 2. UM global snapshot. The approach used for the basic test would needed
-    # large tolerances for the ifort compiler. We keep tolerances small for ifort,
-    # and then we test against the output table.
+    # 2. UM global snapshot.
     - name: UM global against known good output (KGO)
       run: |
         cd driver
         KGO=data/outputs/UKMO/cosp2_output.um_global.${F90}.kgo.$KGO_VERSION.nc
         TST=data/outputs/UKMO/cosp2_output.um_global.nc
         python compare_to_kgo.py ${KGO} ${TST} --atol=${ATOL} --rtol=${RTOL}
-        # ATOL=1.0e-20
-        # RTOL=0.0006
-        # OUTTST=data/outputs/UKMO/cosp2_output.um_global.out
-        # OUTKGO=data/outputs/UKMO/cosp2_output.um_global.${F90}.kgo.${KGO_VERSION}.out
-        # python compare_to_kgo.py ${KGO} ${TST} --atol=${ATOL} --rtol=${RTOL} \
-        #   --noerror=True --stats_file=${OUTTST}
-        # diff ${OUTKGO} ${OUTTST}
     ###############################################################################
     # Produce plots when it fails during global snapshot tests,
     # and create a tarball with outputs.

--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -51,7 +51,7 @@ jobs:
         cd build
         make -j driver
     # Retrieve and expand large data files
-    - name: Retrieve data files
+    - name: Retrieve input files
       run: |
         GDFILE='https://docs.google.com/uc?export=download&id=17eK4_DVEvFOE9Uf6siXJDpWZJKT1aqkU'
         OUTPATH=driver/data/inputs/UKMO/cosp_input.um_global.nc.gz
@@ -59,27 +59,36 @@ jobs:
         gunzip ${OUTPATH}
         cd driver/data/inputs/UKMO
         md5sum -c cosp_input.um_global.nc.md5
+    - name: Retrieve KGOs
+      run: |
+        if [[ "${F90}" = 'gfortran' ]]; then
+          GDFILE1='https://docs.google.com/uc?export=download&id=1s5Ha6Hqnv_hWbRUs8KQpJ4Lxy8uvJDar'
+          GDFILE2='https://docs.google.com/uc?export=download&id=11dKcIL3EQr7s6jbo4f9GsoW0SufesGbq'
+          GDFILE3='https://docs.google.com/uc?export=download&id=1kY1lRgzd0UhDiQef2u-VgTQql_iut3U2'
+        fi
+        if [[ "${F90}" = 'ifort' ]]; then
+          GDFILE1='https://drive.google.com/file/d/1TpXY-vXkwAnym9nNjzUxt1q_8c8T7X8T/view?usp=sharing'
+          GDFILE2='https://drive.google.com/file/d/1ic-2B3dIx1kIoi-Nd1ndLbLAe_LIWDGP/view?usp=drive_link'
+          GDFILE3='https://docs.google.com/uc?export=download&id=1kY1lRgzd0UhDiQef2u-VgTQql_iut3U2'
+        fi
         cd ${GITHUB_WORKSPACE}
-        GDFILE='https://docs.google.com/uc?export=download&id=1s5Ha6Hqnv_hWbRUs8KQpJ4Lxy8uvJDar'
-        OUTPATH=driver/data/outputs/UKMO/cosp2_output.um_global.gfortran.kgo.$KGO_VERSION.nc.gz
-        curl -sSfL -o $OUTPATH $GDFILE
+        OUTPATH=driver/data/outputs/UKMO/cosp2_output.um_global.${F90}.kgo.$KGO_VERSION.nc.gz
+        curl -sSfL -o $OUTPATH $GDFILE1
         gunzip ${OUTPATH}
         cd driver/data/outputs/UKMO
-        md5sum -c cosp2_output.um_global.gfortran.kgo.$KGO_VERSION.nc.md5
+        md5sum -c cosp2_output.um_global.${F90}.kgo.$KGO_VERSION.nc.md5
         cd ${GITHUB_WORKSPACE}
-        GDFILE='https://docs.google.com/uc?export=download&id=11dKcIL3EQr7s6jbo4f9GsoW0SufesGbq'
-        OUTPATH=driver/data/outputs/UKMO/cosp2_output_um.gfortran.kgo.$KGO_VERSION.nc.gz
-        curl -sSfL -o $OUTPATH $GDFILE
+        OUTPATH=driver/data/outputs/UKMO/cosp2_output_um.$F90.kgo.$KGO_VERSION.nc.gz
+        curl -sSfL -o $OUTPATH $GDFILE2
         gunzip ${OUTPATH}
         cd driver/data/outputs/UKMO
-        md5sum -c cosp2_output_um.gfortran.kgo.$KGO_VERSION.nc.md5
+        md5sum -c cosp2_output_um.${F90}.kgo.$KGO_VERSION.nc.md5
         cd ${GITHUB_WORKSPACE}
-        GDFILE='https://docs.google.com/uc?export=download&id=1kY1lRgzd0UhDiQef2u-VgTQql_iut3U2'
-        OUTPATH=driver/data/outputs/UKMO/cosp2_output.um_global_model_levels.gfortran.kgo.$KGO_VERSION.nc.gz
-        curl -sSfL -o $OUTPATH $GDFILE
+        OUTPATH=driver/data/outputs/UKMO/cosp2_output.um_global_model_levels.$F90.kgo.$KGO_VERSION.nc.gz
+        curl -sSfL -o $OUTPATH $GDFILE3
         gunzip ${OUTPATH}
         cd driver/data/outputs/UKMO
-        md5sum -c cosp2_output.um_global_model_levels.gfortran.kgo.$KGO_VERSION.nc.md5
+        md5sum -c cosp2_output.um_global_model_levels.${F90}.kgo.$KGO_VERSION.nc.md5
     ###############################################################################
     # Run COSP2 tests. We could run both tests in one step, but
     # doing it this way the output is easier to interpret.
@@ -98,7 +107,7 @@ jobs:
     - name: Basic against known good output (KGO)
       run: |
         cd driver
-        KGO=data/outputs/UKMO/cosp2_output_um.gfortran.kgo.$KGO_VERSION.nc
+        KGO=data/outputs/UKMO/cosp2_output_um.${F90}.kgo.$KGO_VERSION.nc
         TST=data/outputs/UKMO/cosp2_output_um.nc
         python compare_to_kgo.py ${KGO} ${TST} --atol=${ATOL} --rtol=${RTOL}
     # 2. UM global snapshot. The approach used for the basic test would needed
@@ -107,7 +116,7 @@ jobs:
     - name: UM global against known good output (KGO)
       run: |
         cd driver
-        KGO=data/outputs/UKMO/cosp2_output.um_global.gfortran.kgo.$KGO_VERSION.nc
+        KGO=data/outputs/UKMO/cosp2_output.um_global.${F90}.kgo.$KGO_VERSION.nc
         TST=data/outputs/UKMO/cosp2_output.um_global.nc
         ATOL=1.0e-20
         RTOL=0.0006

--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -7,19 +7,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        compiler: [ifort, ifx]
+        compiler: [ifort]
         include:
         # Set flags for Intel Fortran Compiler Classic
         - compiler: ifort
           fcflags: -m64 -g -traceback -heap-arrays -assume realloc_lhs -extend-source 132 -check bounds,uninit,pointers,stack -stand f08
-        # Set flags for Intel Fortran Compiler
-        - compiler: ifx
-          fcflags: -debug -traceback -O0 -heap-arrays -assume realloc_lhs -extend-source 132 -stand f08
+        # # Set flags for Intel Fortran Compiler
+        # - compiler: ifx
+        #   fcflags: -debug -traceback -O0 -heap-arrays -assume realloc_lhs -extend-source 132 -stand f08
         # Set container images
         - compiler: ifort
           image: ghcr.io/earth-system-radiation/rte-rrtmgp-ci:oneapi
-        - compiler: ifx
-          image: ghcr.io/earth-system-radiation/rte-rrtmgp-ci:oneapi
+        # - compiler: ifx
+        #   image: ghcr.io/earth-system-radiation/rte-rrtmgp-ci:oneapi
     container:
       image: ${{ matrix.image }}
     env:

--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -47,7 +47,6 @@ jobs:
     # like COSP. We tell ifort to use heap arrays.
     - name: Build driver
       run: |
-        source /opt/intel/oneapi/setvars.sh || true
         ${F90} --version
         cd build
         make -j driver

--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -1,0 +1,148 @@
+name: Continuous integration in containers
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  Containerized-CI:
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: [ifort, ifx, nvfortran]
+        include:
+        # Set flags for Intel Fortran Compiler Classic
+        - compiler: ifort
+          fcflags: -m64 -g -traceback -heap-arrays -assume realloc_lhs -extend-source 132 -check bounds,uninit,pointers,stack -stand f08
+        # Set flags for Intel Fortran Compiler
+        - compiler: ifx
+          fcflags: -debug -traceback -O0 -heap-arrays -assume realloc_lhs -extend-source 132 -stand f08
+        # Set flags for NVIDIA Fortran compiler
+        - compiler: nvfortran
+          fcflags: -Mallocatable=03 -Mstandard -Mbounds -Mchkptr -Kieee -Mchkstk
+        # Set container images
+        - compiler: ifort
+          image: ghcr.io/earth-system-radiation/rte-rrtmgp-ci:oneapi
+        - compiler: ifx
+          image: ghcr.io/earth-system-radiation/rte-rrtmgp-ci:oneapi
+        - compiler: nvfortran
+          image: ghcr.io/earth-system-radiation/rte-rrtmgp-ci:nvhpc
+    container:
+      image: ${{ matrix.image }}
+    env:
+      F90: ${{ matrix.compiler }}
+      FC:  ${{ matrix.compiler }}
+      F90FLAGS: ${{ fcflags }}
+      # Make variables:
+      NFHOME: /opt/netcdf-fortran
+      ATOL: 0.0
+      RTOL: 0.0
+      KGO_VERSION: v002
+
+    steps:
+    ###############################################################################
+    # Build COSP and retrieve input and test files
+    ###############################################################################
+    # Build COSP2 driver. Intel Fortran stores automatic arrays in the stack
+    # by default, whereas GNU Fortran stores them in the heap. This can cause
+    # segmentation faults with ifort, especially in memory-intensive applications
+    # like COSP. We tell ifort to use heap arrays.
+    - name: Build driver
+      run: |
+        source /opt/intel/oneapi/setvars.sh || true
+        ${F90} --version
+        cd build
+        make -j driver
+    # Retrieve and expand large data files
+    - name: Retrieve data files
+      run: |
+        GDFILE='https://docs.google.com/uc?export=download&id=17eK4_DVEvFOE9Uf6siXJDpWZJKT1aqkU'
+        OUTPATH=driver/data/inputs/UKMO/cosp_input.um_global.nc.gz
+        wget --no-check-certificate $GDFILE -O $OUTPATH
+        gunzip ${OUTPATH}
+        cd driver/data/inputs/UKMO
+        md5sum -c cosp_input.um_global.nc.md5
+        cd ${GITHUB_WORKSPACE}
+        GDFILE='https://docs.google.com/uc?export=download&id=1s5Ha6Hqnv_hWbRUs8KQpJ4Lxy8uvJDar'
+        OUTPATH=driver/data/outputs/UKMO/cosp2_output.um_global.gfortran.kgo.$KGO_VERSION.nc.gz
+        wget --no-check-certificate $GDFILE -O $OUTPATH
+        gunzip ${OUTPATH}
+        cd driver/data/outputs/UKMO
+        md5sum -c cosp2_output.um_global.gfortran.kgo.$KGO_VERSION.nc.md5
+        cd ${GITHUB_WORKSPACE}
+        GDFILE='https://docs.google.com/uc?export=download&id=11dKcIL3EQr7s6jbo4f9GsoW0SufesGbq'
+        OUTPATH=driver/data/outputs/UKMO/cosp2_output_um.gfortran.kgo.$KGO_VERSION.nc.gz
+        wget --no-check-certificate $GDFILE -O $OUTPATH
+        gunzip ${OUTPATH}
+        cd driver/data/outputs/UKMO
+        md5sum -c cosp2_output_um.gfortran.kgo.$KGO_VERSION.nc.md5
+        cd ${GITHUB_WORKSPACE}
+        GDFILE='https://docs.google.com/uc?export=download&id=1kY1lRgzd0UhDiQef2u-VgTQql_iut3U2'
+        OUTPATH=driver/data/outputs/UKMO/cosp2_output.um_global_model_levels.gfortran.kgo.$KGO_VERSION.nc.gz
+        wget --no-check-certificate $GDFILE -O $OUTPATH
+        gunzip ${OUTPATH}
+        cd driver/data/outputs/UKMO
+        md5sum -c cosp2_output.um_global_model_levels.gfortran.kgo.$KGO_VERSION.nc.md5
+    ###############################################################################
+    # Run COSP2 tests. We could run both tests in one step, but
+    # doing it this way the output is easier to interpret.
+    ###############################################################################
+    # 1. Basic test
+    - name: Basic test, UM global snapshot
+      run: |
+        cd driver/run
+        ./cosp2_test cosp2_input_nl.txt
+        ./cosp2_test cosp2_input_nl.um_global.txt
+    ###############################################################################
+    # Compare results against known good outputs. As above,
+    # we split it in as many steps as tests.
+    ###############################################################################
+    # 1. Basic test
+    - name: Basic against known good output (KGO)
+      run: |
+        cd driver
+        KGO=data/outputs/UKMO/cosp2_output_um.gfortran.kgo.$KGO_VERSION.nc
+        TST=data/outputs/UKMO/cosp2_output_um.nc
+        python compare_to_kgo.py ${KGO} ${TST} --atol=${ATOL} --rtol=${RTOL}
+    # 2. UM global snapshot. The approach used for the basic test would needed
+    # large tolerances for the ifort compiler. We keep tolerances small for ifort,
+    # and then we test against the output table.
+    - name: UM global against known good output (KGO)
+      run: |
+        cd driver
+        KGO=data/outputs/UKMO/cosp2_output.um_global.gfortran.kgo.$KGO_VERSION.nc
+        TST=data/outputs/UKMO/cosp2_output.um_global.nc
+        ATOL=1.0e-20
+        RTOL=0.0006
+        OUTTST=data/outputs/UKMO/cosp2_output.um_global.out
+        OUTKGO=data/outputs/UKMO/cosp2_output.um_global.${F90}.kgo.${KGO_VERSION}.out
+        python compare_to_kgo.py ${KGO} ${TST} --atol=${ATOL} --rtol=${RTOL} \
+          --noerror=True --stats_file=${OUTTST}
+        diff ${OUTKGO} ${OUTTST}
+    ###############################################################################
+    # Produce plots when it fails during global snapshot tests,
+    # and create a tarball with outputs.
+    ###############################################################################
+    - name: Produce plots and create tarball
+      if: failure()
+      run: |
+        TST_MLEV=data/outputs/UKMO/cosp2_output.um_global_model_levels.nc
+        cd driver
+        if [[ -e data/outputs/UKMO/cosp2_output.um_global.nc ]]; then
+          python plot_test_outputs.py
+        fi
+        if [[ -e data/outputs/UKMO/cosp2_output.um_global_model_levels.nc ]]; then
+          python plot_test_outputs.py --tst_file=$TST_MLEV
+        fi
+        cd data/outputs/UKMO
+        tar --ignore-failed-read -czf outputs.UKMO.tgz cosp2_output.um_global.nc \
+          cosp2_output_um.nc cosp2_output.um_global_model_levels.nc *.png \
+          cosp2_output.um_global.out
+        ls -lh
+    ###############################################################################
+    # Make output files available if any test fails
+    ###############################################################################
+    - name: Upload output file if test fails
+      if: failure()
+      uses: actions/upload-artifact@v1.0.0
+      with:
+        name: outputs.UKMO.tgz
+        path: driver/data/outputs/UKMO/outputs.UKMO.tgz

--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -58,31 +58,30 @@ jobs:
     # Retrieve and expand large data files
     - name: Retrieve data files
       run: |
-        sudo apt-get install wget
         GDFILE='https://docs.google.com/uc?export=download&id=17eK4_DVEvFOE9Uf6siXJDpWZJKT1aqkU'
         OUTPATH=driver/data/inputs/UKMO/cosp_input.um_global.nc.gz
-        wget --no-check-certificate $GDFILE -O $OUTPATH
+        curl -sSfL -o $OUTPATH $GDFILE
         gunzip ${OUTPATH}
         cd driver/data/inputs/UKMO
         md5sum -c cosp_input.um_global.nc.md5
         cd ${GITHUB_WORKSPACE}
         GDFILE='https://docs.google.com/uc?export=download&id=1s5Ha6Hqnv_hWbRUs8KQpJ4Lxy8uvJDar'
         OUTPATH=driver/data/outputs/UKMO/cosp2_output.um_global.gfortran.kgo.$KGO_VERSION.nc.gz
-        wget --no-check-certificate $GDFILE -O $OUTPATH
+        curl -sSfL -o $OUTPATH $GDFILE
         gunzip ${OUTPATH}
         cd driver/data/outputs/UKMO
         md5sum -c cosp2_output.um_global.gfortran.kgo.$KGO_VERSION.nc.md5
         cd ${GITHUB_WORKSPACE}
         GDFILE='https://docs.google.com/uc?export=download&id=11dKcIL3EQr7s6jbo4f9GsoW0SufesGbq'
         OUTPATH=driver/data/outputs/UKMO/cosp2_output_um.gfortran.kgo.$KGO_VERSION.nc.gz
-        wget --no-check-certificate $GDFILE -O $OUTPATH
+        curl -sSfL -o $OUTPATH $GDFILE
         gunzip ${OUTPATH}
         cd driver/data/outputs/UKMO
         md5sum -c cosp2_output_um.gfortran.kgo.$KGO_VERSION.nc.md5
         cd ${GITHUB_WORKSPACE}
         GDFILE='https://docs.google.com/uc?export=download&id=1kY1lRgzd0UhDiQef2u-VgTQql_iut3U2'
         OUTPATH=driver/data/outputs/UKMO/cosp2_output.um_global_model_levels.gfortran.kgo.$KGO_VERSION.nc.gz
-        wget --no-check-certificate $GDFILE -O $OUTPATH
+        curl -sSfL -o $OUTPATH $GDFILE
         gunzip ${OUTPATH}
         cd driver/data/outputs/UKMO
         md5sum -c cosp2_output.um_global_model_levels.gfortran.kgo.$KGO_VERSION.nc.md5

--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        compiler: [ifort, ifx, nvfortran]
+        compiler: [ifort, ifx]
         include:
         # Set flags for Intel Fortran Compiler Classic
         - compiler: ifort

--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -17,8 +17,8 @@ jobs:
         # Set flags for Intel Fortran Compiler
         - compiler: ifx
           fcflags: -debug -traceback -O0 -heap-arrays -assume realloc_lhs -extend-source 132 -stand f08
-          gdkgo1: https://docs.google.com/uc?export=download&id=1TpXY-vXkwAnym9nNjzUxt1q_8c8T7X8T
-          gdkgo2: https://docs.google.com/uc?export=download&id=1ic-2B3dIx1kIoi-Nd1ndLbLAe_LIWDGP
+          gdkgo1: https://docs.google.com/uc?export=download&id=19N7wXou-2Zv0oVAnwn4Ucs8Ghr-C0SMt
+          gdkgo2: https://docs.google.com/uc?export=download&id=1EUO6C_v0rq0NMXkLGqZDKX99kknnMRQN
         # Set container images
         # - compiler: ifort
         #   image: ghcr.io/earth-system-radiation/rte-rrtmgp-ci:oneapi

--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -15,9 +15,6 @@ jobs:
         # Set flags for Intel Fortran Compiler
         - compiler: ifx
           fcflags: -debug -traceback -O0 -heap-arrays -assume realloc_lhs -extend-source 132 -stand f08
-        # Set flags for NVIDIA Fortran compiler
-        - compiler: nvfortran
-          fcflags: -Mallocatable=03 -Mstandard -Mbounds -Mchkptr -Kieee -Mchkstk
         # Set container images
         - compiler: ifort
           image: ghcr.io/earth-system-radiation/rte-rrtmgp-ci:oneapi

--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -38,6 +38,11 @@ jobs:
       KGO_VERSION: v002
 
     steps:
+    #
+    # Checks-out repository under $GITHUB_WORKSPACE
+    #
+    - uses: actions/checkout@v4
+    
     ###############################################################################
     # Build COSP and retrieve input and test files
     ###############################################################################

--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -23,8 +23,6 @@ jobs:
           image: ghcr.io/earth-system-radiation/rte-rrtmgp-ci:oneapi
         - compiler: ifx
           image: ghcr.io/earth-system-radiation/rte-rrtmgp-ci:oneapi
-        - compiler: nvfortran
-          image: ghcr.io/earth-system-radiation/rte-rrtmgp-ci:nvhpc
     container:
       image: ${{ matrix.image }}
     env:

--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -70,7 +70,7 @@ jobs:
         curl -sSfL -o $OUTPATH $GDKGO1
         gunzip ${OUTPATH}
         cd driver/data/outputs/UKMO
-        md5sum -c cosp2_output.um_global.${F90}.kgo.$KGO_VERSION.nc.md5
+        md5sum -c cosp2_output_um.${F90}.kgo.$KGO_VERSION.nc.md5
     - name: Retrieve KGOs for global test
       run: |
         cd ${GITHUB_WORKSPACE}
@@ -78,7 +78,7 @@ jobs:
         curl -sSfL -o $OUTPATH $GDKGO2
         gunzip ${OUTPATH}
         cd driver/data/outputs/UKMO
-        md5sum -c cosp2_output_um.${F90}.kgo.$KGO_VERSION.nc.md5
+        md5sum -c cosp2_output.um_global.${F90}.kgo.$KGO_VERSION.nc.md5
     ###############################################################################
     # Run COSP2 tests. Basic test and UM global snapshot
     ###############################################################################

--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -14,7 +14,6 @@ jobs:
           fcflags: -m64 -g -traceback -heap-arrays -assume realloc_lhs -extend-source 132 -check bounds,uninit,pointers,stack -stand f08
           gdkgo1: https://docs.google.com/uc?export=download&id=1TpXY-vXkwAnym9nNjzUxt1q_8c8T7X8T
           gdkgo2: https://docs.google.com/uc?export=download&id=1ic-2B3dIx1kIoi-Nd1ndLbLAe_LIWDGP
-          gdkgo3: https://docs.google.com/uc?export=download&id=1kY1lRgzd0UhDiQef2u-VgTQql_iut3U2
         # # Set flags for Intel Fortran Compiler
         # - compiler: ifx
         #   fcflags: -debug -traceback -O0 -heap-arrays -assume realloc_lhs -extend-source 132 -stand f08
@@ -37,7 +36,6 @@ jobs:
       KGO_VERSION: v002
       GDKGO1: ${{ matrix.gdkgo1 }}
       GDKGO2: ${{ matrix.gdkgo2 }}
-      GDKGO3: ${{ matrix.gdkgo3 }}
     steps:
     #
     # Checks-out repository under $GITHUB_WORKSPACE
@@ -68,7 +66,7 @@ jobs:
     - name: Retrieve KGOs for basic test
       run: |
         cd ${GITHUB_WORKSPACE}
-        OUTPATH=driver/data/outputs/UKMO/cosp2_output.um_global.${F90}.kgo.$KGO_VERSION.nc.gz
+        OUTPATH=driver/data/outputs/UKMO/cosp2_output_um.$F90.kgo.$KGO_VERSION.nc.gz
         curl -sSfL -o $OUTPATH $GDKGO1
         gunzip ${OUTPATH}
         cd driver/data/outputs/UKMO
@@ -76,25 +74,15 @@ jobs:
     - name: Retrieve KGOs for global test
       run: |
         cd ${GITHUB_WORKSPACE}
-        OUTPATH=driver/data/outputs/UKMO/cosp2_output_um.$F90.kgo.$KGO_VERSION.nc.gz
+        OUTPATH=driver/data/outputs/UKMO/cosp2_output.um_global.${F90}.kgo.$KGO_VERSION.nc.gz
         curl -sSfL -o $OUTPATH $GDKGO2
         gunzip ${OUTPATH}
         cd driver/data/outputs/UKMO
         md5sum -c cosp2_output_um.${F90}.kgo.$KGO_VERSION.nc.md5
-    - name: Retrieve KGOs for model levels outputs test
-      run: |
-        cd ${GITHUB_WORKSPACE}
-        OUTPATH=driver/data/outputs/UKMO/cosp2_output.um_global_model_levels.$F90.kgo.$KGO_VERSION.nc.gz
-        curl -sSfL -o $OUTPATH $GDKGO3
-        gunzip ${OUTPATH}
-        cd driver/data/outputs/UKMO
-        md5sum -c cosp2_output.um_global_model_levels.${F90}.kgo.$KGO_VERSION.nc.md5
     ###############################################################################
-    # Run COSP2 tests. We could run both tests in one step, but
-    # doing it this way the output is easier to interpret.
+    # Run COSP2 tests. Basic test and UM global snapshot
     ###############################################################################
-    # 1. Basic test
-    - name: Basic test, UM global snapshot
+    - name: Basic test and UM global snapshot
       run: |
         cd driver/run
         ./cosp2_test cosp2_input_nl.txt

--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -7,21 +7,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        compiler: [ifx]
+        compiler: [ifort, ifx]
         include:
-        # Set flags for Intel Fortran Compiler Classic
-        # - compiler: ifort
-        #   fcflags: -m64 -g -traceback -heap-arrays -assume realloc_lhs -extend-source 132 -check bounds,uninit,pointers,stack -stand f08
-        #   gdkgo1: https://docs.google.com/uc?export=download&id=1TpXY-vXkwAnym9nNjzUxt1q_8c8T7X8T
-        #   gdkgo2: https://docs.google.com/uc?export=download&id=1ic-2B3dIx1kIoi-Nd1ndLbLAe_LIWDGP
-        # Set flags for Intel Fortran Compiler
+        # Flags and KGOs for Intel Fortran Compiler Classic
+        - compiler: ifort
+          fcflags: -m64 -g -traceback -heap-arrays -assume realloc_lhs -extend-source 132 -check bounds,uninit,pointers,stack -stand f08
+          gdkgo1: https://docs.google.com/uc?export=download&id=1TpXY-vXkwAnym9nNjzUxt1q_8c8T7X8T
+          gdkgo2: https://docs.google.com/uc?export=download&id=1ic-2B3dIx1kIoi-Nd1ndLbLAe_LIWDGP
+        # Flags and KGOs for Intel Fortran Compiler
         - compiler: ifx
           fcflags: -debug -traceback -O0 -heap-arrays -assume realloc_lhs -extend-source 132 -stand f08
           gdkgo1: https://docs.google.com/uc?export=download&id=19N7wXou-2Zv0oVAnwn4Ucs8Ghr-C0SMt
           gdkgo2: https://docs.google.com/uc?export=download&id=1EUO6C_v0rq0NMXkLGqZDKX99kknnMRQN
         # Set container images
-        # - compiler: ifort
-        #   image: ghcr.io/earth-system-radiation/rte-rrtmgp-ci:oneapi
+        - compiler: ifort
+          image: ghcr.io/earth-system-radiation/rte-rrtmgp-ci:oneapi
         - compiler: ifx
           image: ghcr.io/earth-system-radiation/rte-rrtmgp-ci:oneapi
     container:

--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -42,7 +42,7 @@ jobs:
     # Checks-out repository under $GITHUB_WORKSPACE
     #
     - uses: actions/checkout@v4
-    
+
     ###############################################################################
     # Build COSP and retrieve input and test files
     ###############################################################################
@@ -58,6 +58,7 @@ jobs:
     # Retrieve and expand large data files
     - name: Retrieve data files
       run: |
+        sudo apt-get install wget
         GDFILE='https://docs.google.com/uc?export=download&id=17eK4_DVEvFOE9Uf6siXJDpWZJKT1aqkU'
         OUTPATH=driver/data/inputs/UKMO/cosp_input.um_global.nc.gz
         wget --no-check-certificate $GDFILE -O $OUTPATH

--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -30,7 +30,7 @@ jobs:
     env:
       F90: ${{ matrix.compiler }}
       FC:  ${{ matrix.compiler }}
-      F90FLAGS: ${{ fcflags }}
+      F90FLAGS:  ${{ matrix.fcflags }}
       # Make variables:
       NFHOME: /opt/netcdf-fortran
       ATOL: 0.0

--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -12,6 +12,9 @@ jobs:
         # Set flags for Intel Fortran Compiler Classic
         - compiler: ifort
           fcflags: -m64 -g -traceback -heap-arrays -assume realloc_lhs -extend-source 132 -check bounds,uninit,pointers,stack -stand f08
+          gdkgo1: https://docs.google.com/uc?export=download&id=1TpXY-vXkwAnym9nNjzUxt1q_8c8T7X8T
+          gdkgo2: https://docs.google.com/uc?export=download&id=1ic-2B3dIx1kIoi-Nd1ndLbLAe_LIWDGP
+          gdkgo3: https://docs.google.com/uc?export=download&id=1kY1lRgzd0UhDiQef2u-VgTQql_iut3U2
         # # Set flags for Intel Fortran Compiler
         # - compiler: ifx
         #   fcflags: -debug -traceback -O0 -heap-arrays -assume realloc_lhs -extend-source 132 -stand f08
@@ -28,10 +31,13 @@ jobs:
       F90FLAGS:  ${{ matrix.fcflags }}
       # Make variables:
       NFHOME: /opt/netcdf-fortran
+      # KGO tests variables
       ATOL: 0.0
       RTOL: 0.0
       KGO_VERSION: v002
-
+      GDKGO1: ${{ matrix.gdkgo1 }}
+      GDKGO2: ${{ matrix.gdkgo2 }}
+      GDKGO3: ${{ matrix.gdkgo3 }}
     steps:
     #
     # Checks-out repository under $GITHUB_WORKSPACE
@@ -59,33 +65,27 @@ jobs:
         gunzip ${OUTPATH}
         cd driver/data/inputs/UKMO
         md5sum -c cosp_input.um_global.nc.md5
-    - name: Retrieve KGOs
+    - name: Retrieve KGOs for basic test
       run: |
-        if [[ "${F90}" = 'gfortran' ]]; then
-          GDFILE1='https://docs.google.com/uc?export=download&id=1s5Ha6Hqnv_hWbRUs8KQpJ4Lxy8uvJDar'
-          GDFILE2='https://docs.google.com/uc?export=download&id=11dKcIL3EQr7s6jbo4f9GsoW0SufesGbq'
-          GDFILE3='https://docs.google.com/uc?export=download&id=1kY1lRgzd0UhDiQef2u-VgTQql_iut3U2'
-        fi
-        if [[ "${F90}" = 'ifort' ]]; then
-          GDFILE1='https://docs.google.com/uc?export=download&id=1TpXY-vXkwAnym9nNjzUxt1q_8c8T7X8T'
-          GDFILE2='https://docs.google.com/uc?export=download&id=1ic-2B3dIx1kIoi-Nd1ndLbLAe_LIWDGP'
-          GDFILE3='https://docs.google.com/uc?export=download&id=1kY1lRgzd0UhDiQef2u-VgTQql_iut3U2'
-        fi
         cd ${GITHUB_WORKSPACE}
         OUTPATH=driver/data/outputs/UKMO/cosp2_output.um_global.${F90}.kgo.$KGO_VERSION.nc.gz
-        curl -sSfL -o $OUTPATH $GDFILE1
+        curl -sSfL -o $OUTPATH $GDKGO1
         gunzip ${OUTPATH}
         cd driver/data/outputs/UKMO
         md5sum -c cosp2_output.um_global.${F90}.kgo.$KGO_VERSION.nc.md5
+    - name: Retrieve KGOs for global test
+      run: |
         cd ${GITHUB_WORKSPACE}
         OUTPATH=driver/data/outputs/UKMO/cosp2_output_um.$F90.kgo.$KGO_VERSION.nc.gz
-        curl -sSfL -o $OUTPATH $GDFILE2
+        curl -sSfL -o $OUTPATH $GDKGO2
         gunzip ${OUTPATH}
         cd driver/data/outputs/UKMO
         md5sum -c cosp2_output_um.${F90}.kgo.$KGO_VERSION.nc.md5
+    - name: Retrieve KGOs for model levels outputs test
+      run: |
         cd ${GITHUB_WORKSPACE}
         OUTPATH=driver/data/outputs/UKMO/cosp2_output.um_global_model_levels.$F90.kgo.$KGO_VERSION.nc.gz
-        curl -sSfL -o $OUTPATH $GDFILE3
+        curl -sSfL -o $OUTPATH $GDKGO3
         gunzip ${OUTPATH}
         cd driver/data/outputs/UKMO
         md5sum -c cosp2_output.um_global_model_levels.${F90}.kgo.$KGO_VERSION.nc.md5
@@ -118,13 +118,14 @@ jobs:
         cd driver
         KGO=data/outputs/UKMO/cosp2_output.um_global.${F90}.kgo.$KGO_VERSION.nc
         TST=data/outputs/UKMO/cosp2_output.um_global.nc
-        ATOL=1.0e-20
-        RTOL=0.0006
-        OUTTST=data/outputs/UKMO/cosp2_output.um_global.out
-        OUTKGO=data/outputs/UKMO/cosp2_output.um_global.${F90}.kgo.${KGO_VERSION}.out
-        python compare_to_kgo.py ${KGO} ${TST} --atol=${ATOL} --rtol=${RTOL} \
-          --noerror=True --stats_file=${OUTTST}
-        diff ${OUTKGO} ${OUTTST}
+        python compare_to_kgo.py ${KGO} ${TST} --atol=${ATOL} --rtol=${RTOL}
+        # ATOL=1.0e-20
+        # RTOL=0.0006
+        # OUTTST=data/outputs/UKMO/cosp2_output.um_global.out
+        # OUTKGO=data/outputs/UKMO/cosp2_output.um_global.${F90}.kgo.${KGO_VERSION}.out
+        # python compare_to_kgo.py ${KGO} ${TST} --atol=${ATOL} --rtol=${RTOL} \
+        #   --noerror=True --stats_file=${OUTTST}
+        # diff ${OUTKGO} ${OUTTST}
     ###############################################################################
     # Produce plots when it fails during global snapshot tests,
     # and create a tarball with outputs.

--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -67,8 +67,8 @@ jobs:
           GDFILE3='https://docs.google.com/uc?export=download&id=1kY1lRgzd0UhDiQef2u-VgTQql_iut3U2'
         fi
         if [[ "${F90}" = 'ifort' ]]; then
-          GDFILE1='https://drive.google.com/file/d/1TpXY-vXkwAnym9nNjzUxt1q_8c8T7X8T/view?usp=sharing'
-          GDFILE2='https://drive.google.com/file/d/1ic-2B3dIx1kIoi-Nd1ndLbLAe_LIWDGP/view?usp=drive_link'
+          GDFILE1='https://docs.google.com/uc?export=download&id=1TpXY-vXkwAnym9nNjzUxt1q_8c8T7X8T'
+          GDFILE2='https://docs.google.com/uc?export=download&id=1ic-2B3dIx1kIoi-Nd1ndLbLAe_LIWDGP'
           GDFILE3='https://docs.google.com/uc?export=download&id=1kY1lRgzd0UhDiQef2u-VgTQql_iut3U2'
         fi
         cd ${GITHUB_WORKSPACE}

--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -72,7 +72,7 @@ jobs:
         curl -sSfL -o $OUTPATH $GDKGO1
         gunzip ${OUTPATH}
         cd driver/data/outputs/UKMO
-        md5sum -c cosp2_output_um.${F90}.kgo.$KGO_VERSION.nc.md5
+        # md5sum -c cosp2_output_um.${F90}.kgo.$KGO_VERSION.nc.md5
     - name: Retrieve KGOs for global test
       run: |
         cd ${GITHUB_WORKSPACE}
@@ -80,7 +80,7 @@ jobs:
         curl -sSfL -o $OUTPATH $GDKGO2
         gunzip ${OUTPATH}
         cd driver/data/outputs/UKMO
-        md5sum -c cosp2_output.um_global.${F90}.kgo.$KGO_VERSION.nc.md5
+        # md5sum -c cosp2_output.um_global.${F90}.kgo.$KGO_VERSION.nc.md5
     ###############################################################################
     # Run COSP2 tests. Basic test and UM global snapshot
     ###############################################################################

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -130,10 +130,9 @@ jobs:
 
     # Build NetCDF FORTRAN library for current compiler
     - name: Build NetCDF FORTRAN library
-      if: contains(matrix.compiler, 'ifort')
+      if: contains(matrix.compiler, 'ifort') && steps.cache-netcdf-fortran.outputs.cache-hit != 'true'
       env:
         FCFLAGS: -fPIC
-      if: steps.cache-netcdf-fortran.outputs.cache-hit != 'true'
       run: |
         source /opt/intel/oneapi/setvars.sh || true
         ${F90} --version

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -37,11 +37,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        compiler: [gfortran-10, gfortran-11, gfortran-12, ifort]
+        compiler: [gfortran-10, gfortran-11, gfortran-12]
     env:
       F90: ${{ matrix.compiler }}
       FC:  ${{ matrix.compiler }}
       F90FLAGS: "-O3 -ffree-line-length-none -fcheck=bounds -finit-real=nan"
+      NFHOME: /usr
       ATOL: 0.0
       RTOL: 0.0
       KGO_VERSION: v002
@@ -63,96 +64,18 @@ jobs:
         python-version: 3.11
     - name: Install python packages
       run: conda install --yes cartopy matplotlib netcdf4
-    ###############################################################################
-    # FORTRAN compilers
-    ###############################################################################
-    #
-    # Intel compilers
-    #
-    - name: cache-intel-compilers
-      id: cache-intel-compilers
-      if: contains(matrix.compiler, 'ifort')
-      uses: actions/cache@v2
-      with:
-        path: /opt/intel
-        key: intel-${{ runner.os }}-compilers-b
-
-    # https://software.intel.com/content/www/us/en/develop/articles/installing-intel-oneapi-toolkits-via-apt.html
-    # List of packages from Docler file at
-    #    https://github.com/intel/oneapi-containers/blob/master/images/docker/hpckit-devel-ubuntu18.04/Dockerfile
-    - name: Install Intel compilers and libraries
-      if: contains(matrix.compiler, 'ifort') && steps.cache-intel-compilers.outputs.cache-hit != 'true'
-      run: |
-        wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
-        sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
-        sudo add-apt-repository "deb https://apt.repos.intel.com/oneapi all main"
-        sudo apt-get update
-        sudo apt-get install intel-hpckit-getting-started intel-oneapi-clck intel-oneapi-common-licensing intel-oneapi-common-vars
-        sudo apt-get install intel-oneapi-dev-utilities  intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic intel-oneapi-compiler-fortran intel-oneapi-itac
-
-    ###############################################################################
-    # Compiler-specific environment
-    ###############################################################################
-    - name: Environment for Gfortran compiler
-      if: contains(matrix.compiler, 'gfortran')
-      run: echo "NFHOME=/usr" > $GITHUB_ENV
-
-    - name: Environment for ifort compiler
-      if: contains(matrix.compiler, 'ifort')
-      run: |
-        echo "CC=icx" > $GITHUB_ENV
-        echo "FC=ifort" > $GITHUB_ENV
-        echo "F90FLAGS=-O3 -heap-arrays" > $GITHUB_ENV
-        echo "NFHOME=/home/runner/netcdf-fortran" > $GITHUB_ENV
-        echo "LD_LIBRARY_PATH=/home/runner/netcdf-fortran/lib" > $GITHUB_ENV
-
-    ###############################################################################
     # NetCDF C and FORTRAN libraries
-    ###############################################################################
-    # NetCDF C library
     - name: Install NetCDF library
       run: |
         sudo apt-get update
-        sudo apt-get install libnetcdf-dev
+        sudo apt-get install libnetcdff-dev
 
-    - name: Install NetCDF Fortran library
-      if: contains(matrix.compiler, 'gfortran')
-      run: sudo apt-get install libnetcdff-dev
-
-    # Cache netcdf FORTRAN library
-    - name: cache-netcdf-fortran
-      id: cache-netcdf-fortran
-      if: contains(matrix.compiler, 'ifort')
-      uses: actions/cache@v2
-      with:
-        path: /home/runner/netcdf-fortran
-        key: netcdf-fortran-4.4.4a-${{ runner.os }}-${{ matrix.compiler }}-v02
-
-    # Build NetCDF FORTRAN library for current compiler
-    - name: Build NetCDF FORTRAN library
-      if: contains(matrix.compiler, 'ifort') && steps.cache-netcdf-fortran.outputs.cache-hit != 'true'
-      env:
-        FCFLAGS: -fPIC
-      run: |
-        source /opt/intel/oneapi/setvars.sh || true
-        which ifort
-        which ifx
-        ${F90} --version
-        git clone https://github.com/Unidata/netcdf-fortran.git --branch v4.4.4
-        cd netcdf-fortran
-        ./configure --prefix=${NFHOME}
-        make -j
-        sudo make install
     ###############################################################################
     # Build COSP and retrieve input and test files
     ###############################################################################
-    # Build COSP2 driver. Intel Fortran stores automatic arrays in the stack
-    # by default, whereas GNU Fortran stores them in the heap. This can cause
-    # segmentation faults with ifort, especially in memory-intensive applications
-    # like COSP. We tell ifort to use heap arrays.
+    # Build COSP2 driver. 
     - name: Build driver
       run: |
-        source /opt/intel/oneapi/setvars.sh || true
         ${F90} --version
         cd build
         make -j driver
@@ -199,7 +122,6 @@ jobs:
         ./cosp2_test cosp2_input_nl.um_global.txt
     # 2. UM global snapshot. Diagnostics on model levels.
     - name: UM global snapshot. Diagnostics on model levels.
-      if: contains(matrix.compiler, 'gfortran')
       run: |
         cd driver/run
         ./cosp2_test cosp2_input_nl.um_global_model_levels.txt cosp2_output_nl.um_global_model_levels.txt
@@ -210,36 +132,19 @@ jobs:
     # 1. Basic test
     - name: Basic against known good output (KGO)
       run: |
-        if [[ "${F90}" != 'gfortran' ]]; then
-          ATOL=1.0e-20
-          RTOL=0.0006
-        fi
         cd driver
         KGO=data/outputs/UKMO/cosp2_output_um.gfortran.kgo.$KGO_VERSION.nc
         TST=data/outputs/UKMO/cosp2_output_um.nc
         python compare_to_kgo.py ${KGO} ${TST} --atol=${ATOL} --rtol=${RTOL}
-    # 2. UM global snapshot. The approach used for the basic test would needed
-    # large tolerances for the ifort compiler. We keep tolerances small for ifort,
-    # and then we test against the output table.
+    # 2. UM global snapshot. 
     - name: UM global against known good output (KGO)
       run: |
         cd driver
         KGO=data/outputs/UKMO/cosp2_output.um_global.gfortran.kgo.$KGO_VERSION.nc
         TST=data/outputs/UKMO/cosp2_output.um_global.nc
-        if [[ "${F90}" = 'gfortran' ]]; then
-          python compare_to_kgo.py ${KGO} ${TST} --atol=${ATOL} --rtol=${RTOL}
-        else
-          ATOL=1.0e-20
-          RTOL=0.0006
-          OUTTST=data/outputs/UKMO/cosp2_output.um_global.out
-          OUTKGO=data/outputs/UKMO/cosp2_output.um_global.${F90}.kgo.${KGO_VERSION}.out
-          python compare_to_kgo.py ${KGO} ${TST} --atol=${ATOL} --rtol=${RTOL} \
-            --noerror=True --stats_file=${OUTTST}
-          diff ${OUTKGO} ${OUTTST}
-        fi
-    # 3. UM global snapshot. Diagnostics on model levels. Only gfortran.
+        python compare_to_kgo.py ${KGO} ${TST} --atol=${ATOL} --rtol=${RTOL}
+    # 3. UM global snapshot. Diagnostics on model levels.
     - name: UM global on model levels against known good output (KGO)
-      if: contains(matrix.compiler, 'gfortran')
       run: |
         cd driver
         KGO=data/outputs/UKMO/cosp2_output.um_global_model_levels.gfortran.kgo.$KGO_VERSION.nc

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -35,6 +35,7 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-22.04
     strategy:
+      fail-fast: false
       matrix:
         compiler: [gfortran-10, gfortran-11, gfortran-12, ifort]
     env:
@@ -114,9 +115,14 @@ jobs:
     - name: Install NetCDF library
       run: sudo apt-get install libnetcdf-dev
 
+    - name: Install NetCDF Fortran library
+      if: contains(matrix.compiler, 'gfortran')
+      run: sudo apt-get install libnetcdff-dev
+
     # Cache netcdf FORTRAN library
     - name: cache-netcdf-fortran
       id: cache-netcdf-fortran
+      if: contains(matrix.compiler, 'ifort')
       uses: actions/cache@v2
       with:
         path: /home/runner/netcdf-fortran
@@ -124,6 +130,7 @@ jobs:
 
     # Build NetCDF FORTRAN library for current compiler
     - name: Build NetCDF FORTRAN library
+      if: contains(matrix.compiler, 'ifort')
       env:
         FCFLAGS: -fPIC
       if: steps.cache-netcdf-fortran.outputs.cache-hit != 'true'

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -33,13 +33,13 @@ jobs:
   # This workflow contains a single job called "test"
   test:
     # The type of runner that the job will run on
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        fortran-compiler: [gfortran, gfortran-8, gfortran-7, ifort]
+        compiler: [gfortran-10, gfortran-11, gfortran-12, ifort]
     env:
-      F90: ${{ matrix.fortran-compiler }}
-      FC: ${{ matrix.fortran-compiler }}
+      F90: ${{ matrix.compiler }}
+      FC: ${{ matrix.compiler }}
       F90FLAGS: "-O3 -ffree-line-length-none -fcheck=bounds -finit-real=nan"
       ATOL: 0.0
       RTOL: 0.0
@@ -57,11 +57,11 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.11
     - name: Setup conda
       uses: s-weigand/setup-conda@v1
       with:
-        python-version: 3.7
+        python-version: 3.11
     - name: Install python packages
       run: conda install --yes cartopy matplotlib netcdf4
     # Update system packages
@@ -74,17 +74,11 @@ jobs:
     # FORTRAN compilers
     ###############################################################################
     #
-    # Install gfortran compiler
-    #
-    - name: Install gfortran compiler
-      if: contains(matrix.fortran-compiler, 'gfortran')
-      run: sudo apt-get install ${{ matrix.fortran-compiler }}
-    #
     # Intel compilers
     #
     - name: cache-intel-compilers
       id: cache-intel-compilers
-      if: contains(matrix.fortran-compiler, 'ifort')
+      if: contains(matrix.compiler, 'ifort')
       uses: actions/cache@v2
       with:
         path: /opt/intel
@@ -94,7 +88,7 @@ jobs:
     # List of packages from Docler file at
     #    https://github.com/intel/oneapi-containers/blob/master/images/docker/hpckit-devel-ubuntu18.04/Dockerfile
     - name: Install Intel compilers and libraries
-      if: contains(matrix.fortran-compiler, 'ifort') && steps.cache-intel-compilers.outputs.cache-hit != 'true'
+      if: contains(matrix.compiler, 'ifort') && steps.cache-intel-compilers.outputs.cache-hit != 'true'
       run: |
         wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
         sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
@@ -103,43 +97,16 @@ jobs:
         sudo apt-get install intel-hpckit-getting-started intel-oneapi-clck intel-oneapi-common-licensing intel-oneapi-common-vars
         sudo apt-get install intel-oneapi-dev-utilities  intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic intel-oneapi-compiler-fortran intel-oneapi-itac
 
-    #
-    # Nvidia compilers
-    #
-    - name: cache-nvidia-compilers
-      id: cache-nvidia-compilers
-      if: contains(matrix.fortran-compiler, 'nvfortran')
-      uses: actions/cache@v2
-      with:
-        path: /opt/nvidia/hpc_sdk/
-        key: nvhpc-${{ runner.os }}-2020-20.7
-
-    - name: Nvidia setup compilers
-      if: contains(matrix.fortran-compiler, 'nvfortran') && steps.cache-nvidia-compilers.outputs.cache-hit != 'true'
-      env:
-        NVCOMPILERS: /opt/nvidia/hpc_sdk
-      run: |
-        wget -q https://developer.download.nvidia.com/hpc-sdk/nvhpc-20-7_20.7_amd64.deb https://developer.download.nvidia.com/hpc-sdk/nvhpc-2020_20.7_amd64.deb
-        sudo apt-get install ./nvhpc-20-7_20.7_amd64.deb ./nvhpc-2020_20.7_amd64.deb
     ###############################################################################
     # Compiler-specific environment
     ###############################################################################
-    # Environments for ifort and nvidia compilers
+    # Environment for Intel compilers
     - name: Environment for ifort compiler
-      if: contains(matrix.fortran-compiler, 'ifort')
+      if: contains(matrix.compiler, 'ifort')
       run: |
         echo "CC=icx" > $GITHUB_ENV
         echo "FC=ifort" > $GITHUB_ENV
         echo "F90FLAGS=-O3 -heap-arrays" > $GITHUB_ENV
-    - name: Environment for nvfortran compiler
-      env:
-        NVCOMPILERS: /opt/nvidia/hpc_sdk
-      if: contains(matrix.fortran-compiler, 'nvfortran')
-      run: |
-        echo "CC=nvc" > $GITHUB_ENV
-        echo "FC=nvfortran" > $GITHUB_ENV
-        echo "F90FLAGS=-Mallocatable=03 -Mstandard -Mbounds -Mchkptr -Kieee -Mchkstk" > $GITHUB_ENV
-        echo "${NVCOMPILERS}/Linux_x86_64/20.7/compilers/bin" >> $GITHUB_PATH
     ###############################################################################
     # NetCDF C and FORTRAN libraries
     ###############################################################################
@@ -153,7 +120,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: /home/runner/netcdf-fortran
-        key: netcdf-fortran-4.4.4a-${{ runner.os }}-${{ matrix.fortran-compiler }}-v02
+        key: netcdf-fortran-4.4.4a-${{ runner.os }}-${{ matrix.compiler }}-v02
 
     # Build NetCDF FORTRAN library for current compiler
     - name: Build NetCDF FORTRAN library
@@ -216,26 +183,18 @@ jobs:
     # doing it this way the output is easier to interpret.
     ###############################################################################
     # 1. Basic test
-    - name: Basic test
+    - name: Basic test, UM global snapshot
       run: |
         source /opt/intel/oneapi/setvars.sh || true
         cd driver/run
         ./cosp2_test cosp2_input_nl.txt
-    # 2. UM global snapshot
-    - name: UM global snapshot
-      run: |
-        source /opt/intel/oneapi/setvars.sh || true
-        cd driver/run
         ./cosp2_test cosp2_input_nl.um_global.txt
-    # 3. UM global snapshot. Diagnostics on model levels.
+    # 2. UM global snapshot. Diagnostics on model levels.
     - name: UM global snapshot. Diagnostics on model levels.
+      if: contains(matrix.compiler, gfortran)
       run: |
-        if [[ "${F90}" = 'gfortran' ]]; then
-          cd driver/run
-          ./cosp2_test cosp2_input_nl.um_global_model_levels.txt cosp2_output_nl.um_global_model_levels.txt
-        else
-          echo "Test is only run for gfortran compiler."
-        fi
+        cd driver/run
+        ./cosp2_test cosp2_input_nl.um_global_model_levels.txt cosp2_output_nl.um_global_model_levels.txt
     ###############################################################################
     # Compare results against known good outputs. As above,
     # we split it in as many steps as tests.
@@ -272,15 +231,12 @@ jobs:
         fi
     # 3. UM global snapshot. Diagnostics on model levels. Only gfortran.
     - name: UM global on model levels against known good output (KGO)
+      if: contains(matrix.compiler, gfortran)
       run: |
         cd driver
         KGO=data/outputs/UKMO/cosp2_output.um_global_model_levels.gfortran.kgo.$KGO_VERSION.nc
         TST=data/outputs/UKMO/cosp2_output.um_global_model_levels.nc
-        if [[ "${F90}" = 'gfortran' ]]; then
           python compare_to_kgo.py ${KGO} ${TST} --atol=${ATOL} --rtol=${RTOL}
-        else
-          echo "Test only run for gfortran compiler."
-        fi
     ###############################################################################
     # Produce plots when it fails during global snapshot tests,
     # and create a tarball with outputs.

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -191,7 +191,7 @@ jobs:
         ./cosp2_test cosp2_input_nl.um_global.txt
     # 2. UM global snapshot. Diagnostics on model levels.
     - name: UM global snapshot. Diagnostics on model levels.
-      if: contains(matrix.compiler, gfortran)
+      if: contains(matrix.compiler, 'gfortran')
       run: |
         cd driver/run
         ./cosp2_test cosp2_input_nl.um_global_model_levels.txt cosp2_output_nl.um_global_model_levels.txt
@@ -231,7 +231,7 @@ jobs:
         fi
     # 3. UM global snapshot. Diagnostics on model levels. Only gfortran.
     - name: UM global on model levels against known good output (KGO)
-      if: contains(matrix.compiler, gfortran)
+      if: contains(matrix.compiler, 'gfortran')
       run: |
         cd driver
         KGO=data/outputs/UKMO/cosp2_output.um_global_model_levels.gfortran.kgo.$KGO_VERSION.nc

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -116,7 +116,7 @@ jobs:
         curl -sSfL -o $OUTPATH $GDKGO3
         gunzip ${OUTPATH}
         cd driver/data/outputs/UKMO
-        md5sum -c cosp2_output.um_global_model_levels.${F90_SHORT_NAME}.kgo.$KGO_VERSION.nc.md5        cd ${GITHUB_WORKSPACE}
+        md5sum -c cosp2_output.um_global_model_levels.${F90_SHORT_NAME}.kgo.$KGO_VERSION.nc.md5
     ###############################################################################
     # Run COSP2 tests. We could run both tests in one step, but
     # doing it this way the output is easier to interpret.

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -46,6 +46,9 @@ jobs:
       ATOL: 0.0
       RTOL: 0.0
       KGO_VERSION: v002
+      GDKGO1: https://docs.google.com/uc?export=download&id=11dKcIL3EQr7s6jbo4f9GsoW0SufesGbq
+      GDKGO2: https://docs.google.com/uc?export=download&id=1s5Ha6Hqnv_hWbRUs8KQpJ4Lxy8uvJDar
+      GDKGO3: https://docs.google.com/uc?export=download&id=1kY1lRgzd0UhDiQef2u-VgTQql_iut3U2
     # Sequence of tasks that will be executed as part of the job
     steps:
     ###############################################################################
@@ -80,35 +83,38 @@ jobs:
         cd build
         make -j driver
     # Retrieve and expand large data files
-    - name: Retrieve data files
+    - name: Retrieve input files
       run: |
         GDFILE='https://docs.google.com/uc?export=download&id=17eK4_DVEvFOE9Uf6siXJDpWZJKT1aqkU'
         OUTPATH=driver/data/inputs/UKMO/cosp_input.um_global.nc.gz
-        wget --no-check-certificate $GDFILE -O $OUTPATH
+        curl -sSfL -o $OUTPATH $GDFILE
         gunzip ${OUTPATH}
         cd driver/data/inputs/UKMO
         md5sum -c cosp_input.um_global.nc.md5
+    - name: Retrieve KGOs for basic test
+      run: |
         cd ${GITHUB_WORKSPACE}
-        GDFILE='https://docs.google.com/uc?export=download&id=1s5Ha6Hqnv_hWbRUs8KQpJ4Lxy8uvJDar'
-        OUTPATH=driver/data/outputs/UKMO/cosp2_output.um_global.gfortran.kgo.$KGO_VERSION.nc.gz
-        wget --no-check-certificate $GDFILE -O $OUTPATH
+        OUTPATH=driver/data/outputs/UKMO/cosp2_output_um.$F90.kgo.$KGO_VERSION.nc.gz
+        curl -sSfL -o $OUTPATH $GDKGO1
         gunzip ${OUTPATH}
         cd driver/data/outputs/UKMO
-        md5sum -c cosp2_output.um_global.gfortran.kgo.$KGO_VERSION.nc.md5
+        md5sum -c cosp2_output_um.${F90}.kgo.$KGO_VERSION.nc.md5
+    - name: Retrieve KGOs for global test
+      run: |
         cd ${GITHUB_WORKSPACE}
-        GDFILE='https://docs.google.com/uc?export=download&id=11dKcIL3EQr7s6jbo4f9GsoW0SufesGbq'
-        OUTPATH=driver/data/outputs/UKMO/cosp2_output_um.gfortran.kgo.$KGO_VERSION.nc.gz
-        wget --no-check-certificate $GDFILE -O $OUTPATH
+        OUTPATH=driver/data/outputs/UKMO/cosp2_output.um_global.${F90}.kgo.$KGO_VERSION.nc.gz
+        curl -sSfL -o $OUTPATH $GDKGO2
         gunzip ${OUTPATH}
         cd driver/data/outputs/UKMO
-        md5sum -c cosp2_output_um.gfortran.kgo.$KGO_VERSION.nc.md5
+        md5sum -c cosp2_output.um_global.${F90}.kgo.$KGO_VERSION.nc.md5        cd ${GITHUB_WORKSPACE}
+    - name: Retrieve KGOs for global test with outputs on model levels
+      run: |
         cd ${GITHUB_WORKSPACE}
-        GDFILE='https://docs.google.com/uc?export=download&id=1kY1lRgzd0UhDiQef2u-VgTQql_iut3U2'
-        OUTPATH=driver/data/outputs/UKMO/cosp2_output.um_global_model_levels.gfortran.kgo.$KGO_VERSION.nc.gz
-        wget --no-check-certificate $GDFILE -O $OUTPATH
+        OUTPATH=driver/data/outputs/UKMO/cosp2_output.um_global_model_levels.${F90}.kgo.$KGO_VERSION.nc.gz
+        curl -sSfL -o $OUTPATH $GDKGO3
         gunzip ${OUTPATH}
         cd driver/data/outputs/UKMO
-        md5sum -c cosp2_output.um_global_model_levels.gfortran.kgo.$KGO_VERSION.nc.md5
+        md5sum -c cosp2_output.um_global_model_levels.${F90}.kgo.$KGO_VERSION.nc.md5        cd ${GITHUB_WORKSPACE}
     ###############################################################################
     # Run COSP2 tests. We could run both tests in one step, but
     # doing it this way the output is easier to interpret.

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -26,12 +26,12 @@
 # THE POSSIBILITY OF SUCH DAMAGE.
 
 # Workflow for continuous integration tests
-name: CI
+name: Continuous integration gfortran compilers
 on: [push, pull_request, workflow_dispatch]
 
 jobs:
-  # This workflow contains a single job called "test"
-  test:
+  # This workflow contains a single job called "ci_gfortran"
+  ci_gfortran:
     # The type of runner that the job will run on
     runs-on: ubuntu-22.04
     strategy:
@@ -52,10 +52,10 @@ jobs:
     # Initial steps
     ###############################################################################
     # Checks-out repository under $GITHUB_WORKSPACE
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     # Set up Python and install dependencies
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.11
     - name: Setup conda

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -59,11 +59,11 @@ jobs:
     - uses: actions/checkout@v4
     # Set up Python and install dependencies
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.11
     - name: Setup conda
-      uses: s-weigand/setup-conda@v1
+      uses: s-weigand/setup-conda@v1.2.1
       with:
         python-version: 3.11
     - name: Install python packages

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -95,7 +95,7 @@ jobs:
     ###############################################################################
     - name: Environment for Gfortran compiler
       if: contains(matrix.compiler, 'gfortran')
-      run: echo "NFHOME=/usr/include" > $GITHUB_ENV
+      run: echo "NFHOME=/usr" > $GITHUB_ENV
 
     - name: Environment for ifort compiler
       if: contains(matrix.compiler, 'ifort')

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -27,7 +27,7 @@
 
 # Workflow for continuous integration tests
 name: CI
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   # This workflow contains a single job called "test"

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         compiler: [gfortran-10, gfortran-11, gfortran-12]
-        python-version: 3.11
+        python-version: [3.11]
     env:
       F90: ${{ matrix.compiler }}
       FC:  ${{ matrix.compiler }}

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -49,6 +49,7 @@ jobs:
       GDKGO1: https://docs.google.com/uc?export=download&id=11dKcIL3EQr7s6jbo4f9GsoW0SufesGbq
       GDKGO2: https://docs.google.com/uc?export=download&id=1s5Ha6Hqnv_hWbRUs8KQpJ4Lxy8uvJDar
       GDKGO3: https://docs.google.com/uc?export=download&id=1kY1lRgzd0UhDiQef2u-VgTQql_iut3U2
+      F90_SHORT_NAME: gfortran
     # Sequence of tasks that will be executed as part of the job
     steps:
     ###############################################################################
@@ -94,27 +95,28 @@ jobs:
     - name: Retrieve KGOs for basic test
       run: |
         cd ${GITHUB_WORKSPACE}
-        OUTPATH=driver/data/outputs/UKMO/cosp2_output_um.$F90.kgo.$KGO_VERSION.nc.gz
+        OUTPATH=driver/data/outputs/UKMO/cosp2_output_um.${F90_SHORT_NAME}.kgo.$KGO_VERSION.nc.gz
         curl -sSfL -o $OUTPATH $GDKGO1
         gunzip ${OUTPATH}
         cd driver/data/outputs/UKMO
-        md5sum -c cosp2_output_um.${F90}.kgo.$KGO_VERSION.nc.md5
+        md5sum -c cosp2_output_um.${F90_SHORT_NAME}.kgo.$KGO_VERSION.nc.md5
     - name: Retrieve KGOs for global test
       run: |
         cd ${GITHUB_WORKSPACE}
-        OUTPATH=driver/data/outputs/UKMO/cosp2_output.um_global.${F90}.kgo.$KGO_VERSION.nc.gz
+        OUTPATH=driver/data/outputs/UKMO/cosp2_output.um_global.${F90_SHORT_NAME}.kgo.$KGO_VERSION.nc.gz
         curl -sSfL -o $OUTPATH $GDKGO2
         gunzip ${OUTPATH}
         cd driver/data/outputs/UKMO
-        md5sum -c cosp2_output.um_global.${F90}.kgo.$KGO_VERSION.nc.md5        cd ${GITHUB_WORKSPACE}
+        md5sum -c cosp2_output.um_global.${F90_SHORT_NAME}.kgo.$KGO_VERSION.nc.md5
+        cd ${GITHUB_WORKSPACE}
     - name: Retrieve KGOs for global test with outputs on model levels
       run: |
         cd ${GITHUB_WORKSPACE}
-        OUTPATH=driver/data/outputs/UKMO/cosp2_output.um_global_model_levels.${F90}.kgo.$KGO_VERSION.nc.gz
+        OUTPATH=driver/data/outputs/UKMO/cosp2_output.um_global_model_levels.${F90_SHORT_NAME}.kgo.$KGO_VERSION.nc.gz
         curl -sSfL -o $OUTPATH $GDKGO3
         gunzip ${OUTPATH}
         cd driver/data/outputs/UKMO
-        md5sum -c cosp2_output.um_global_model_levels.${F90}.kgo.$KGO_VERSION.nc.md5        cd ${GITHUB_WORKSPACE}
+        md5sum -c cosp2_output.um_global_model_levels.${F90_SHORT_NAME}.kgo.$KGO_VERSION.nc.md5        cd ${GITHUB_WORKSPACE}
     ###############################################################################
     # Run COSP2 tests. We could run both tests in one step, but
     # doing it this way the output is easier to interpret.
@@ -139,21 +141,21 @@ jobs:
     - name: Basic against known good output (KGO)
       run: |
         cd driver
-        KGO=data/outputs/UKMO/cosp2_output_um.gfortran.kgo.$KGO_VERSION.nc
+        KGO=data/outputs/UKMO/cosp2_output_um.${F90_SHORT_NAME}.kgo.$KGO_VERSION.nc
         TST=data/outputs/UKMO/cosp2_output_um.nc
         python compare_to_kgo.py ${KGO} ${TST} --atol=${ATOL} --rtol=${RTOL}
     # 2. UM global snapshot. 
     - name: UM global against known good output (KGO)
       run: |
         cd driver
-        KGO=data/outputs/UKMO/cosp2_output.um_global.gfortran.kgo.$KGO_VERSION.nc
+        KGO=data/outputs/UKMO/cosp2_output.um_global.${F90_SHORT_NAME}.kgo.$KGO_VERSION.nc
         TST=data/outputs/UKMO/cosp2_output.um_global.nc
         python compare_to_kgo.py ${KGO} ${TST} --atol=${ATOL} --rtol=${RTOL}
     # 3. UM global snapshot. Diagnostics on model levels.
     - name: UM global on model levels against known good output (KGO)
       run: |
         cd driver
-        KGO=data/outputs/UKMO/cosp2_output.um_global_model_levels.gfortran.kgo.$KGO_VERSION.nc
+        KGO=data/outputs/UKMO/cosp2_output.um_global_model_levels.${F90_SHORT_NAME}.kgo.$KGO_VERSION.nc
         TST=data/outputs/UKMO/cosp2_output.um_global_model_levels.nc
           python compare_to_kgo.py ${KGO} ${TST} --atol=${ATOL} --rtol=${RTOL}
     ###############################################################################

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -99,7 +99,7 @@ jobs:
     ###############################################################################
     # Compiler-specific environment
     ###############################################################################
-    - name: Environment for ifort compiler
+    - name: Environment for Gfortran compiler
       if: contains(matrix.compiler, 'gfortran')
       run: echo "NFHOME=/usr/include" > $GITHUB_ENV
 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -38,6 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         compiler: [gfortran-10, gfortran-11, gfortran-12]
+        python-version: 3.11
     env:
       F90: ${{ matrix.compiler }}
       FC:  ${{ matrix.compiler }}
@@ -61,11 +62,15 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.11
+        python-version: ${{ matrix.python-version }}
     - name: Setup conda
-      uses: s-weigand/setup-conda@v1.2.1
+      # uses: s-weigand/setup-conda@v1.2.1
+      # with:
+      #   python-version: 3.11
+      uses: conda-incubator/setup-miniconda@v3.0.3
       with:
-        python-version: 3.11
+        auto-update-conda: true
+        python-version: ${{ matrix.python-version }}
     - name: Install python packages
       run: conda install --yes cartopy matplotlib netcdf4
     # NetCDF C and FORTRAN libraries

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -45,8 +45,6 @@ jobs:
       ATOL: 0.0
       RTOL: 0.0
       KGO_VERSION: v002
-      NFHOME: /home/runner/netcdf-fortran
-      LD_LIBRARY_PATH: /home/runner/netcdf-fortran/lib
     # Sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out repository under $GITHUB_WORKSPACE
@@ -101,13 +99,19 @@ jobs:
     ###############################################################################
     # Compiler-specific environment
     ###############################################################################
-    # Environment for Intel compilers
+    - name: Environment for ifort compiler
+      if: contains(matrix.compiler, 'gfortran')
+      run: echo "NFHOME=/usr/include" > $GITHUB_ENV
+
     - name: Environment for ifort compiler
       if: contains(matrix.compiler, 'ifort')
       run: |
         echo "CC=icx" > $GITHUB_ENV
         echo "FC=ifort" > $GITHUB_ENV
         echo "F90FLAGS=-O3 -heap-arrays" > $GITHUB_ENV
+        echo "NFHOME=/home/runner/netcdf-fortran" > $GITHUB_ENV
+        echo "LD_LIBRARY_PATH=/home/runner/netcdf-fortran/lib" > $GITHUB_ENV
+
     ###############################################################################
     # NetCDF C and FORTRAN libraries
     ###############################################################################

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -40,18 +40,18 @@ jobs:
         compiler: [gfortran-10, gfortran-11, gfortran-12, ifort]
     env:
       F90: ${{ matrix.compiler }}
-      FC: ${{ matrix.compiler }}
+      FC:  ${{ matrix.compiler }}
       F90FLAGS: "-O3 -ffree-line-length-none -fcheck=bounds -finit-real=nan"
       ATOL: 0.0
       RTOL: 0.0
       KGO_VERSION: v002
     # Sequence of tasks that will be executed as part of the job
     steps:
-    # Checks-out repository under $GITHUB_WORKSPACE
-    - uses: actions/checkout@v2
     ###############################################################################
     # Initial steps
     ###############################################################################
+    # Checks-out repository under $GITHUB_WORKSPACE
+    - uses: actions/checkout@v2
     # Set up Python and install dependencies
     - name: Set up Python
       uses: actions/setup-python@v2
@@ -63,12 +63,6 @@ jobs:
         python-version: 3.11
     - name: Install python packages
       run: conda install --yes cartopy matplotlib netcdf4
-    # Update system packages
-    - name: Update system packages
-      run: sudo apt-get update
-    # Non compiler-specific environment
-    - name: Non compiler-specific environment
-      run: export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${NFHOME}/lib
     ###############################################################################
     # FORTRAN compilers
     ###############################################################################
@@ -117,7 +111,9 @@ jobs:
     ###############################################################################
     # NetCDF C library
     - name: Install NetCDF library
-      run: sudo apt-get install libnetcdf-dev
+      run: |
+        sudo apt-get update
+        sudo apt-get install libnetcdf-dev
 
     - name: Install NetCDF Fortran library
       if: contains(matrix.compiler, 'gfortran')
@@ -139,6 +135,8 @@ jobs:
         FCFLAGS: -fPIC
       run: |
         source /opt/intel/oneapi/setvars.sh || true
+        which ifort
+        which ifx
         ${F90} --version
         git clone https://github.com/Unidata/netcdf-fortran.git --branch v4.4.4
         cd netcdf-fortran

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -39,6 +39,9 @@ jobs:
       matrix:
         compiler: [gfortran-10, gfortran-11, gfortran-12]
         python-version: [3.11]
+    defaults:
+      run:
+        shell: bash -el {0}
     env:
       F90: ${{ matrix.compiler }}
       FC:  ${{ matrix.compiler }}
@@ -58,21 +61,15 @@ jobs:
     ###############################################################################
     # Checks-out repository under $GITHUB_WORKSPACE
     - uses: actions/checkout@v4
-    # Set up Python and install dependencies
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Setup conda
-      # uses: s-weigand/setup-conda@v1.2.1
-      # with:
-      #   python-version: 3.11
+    # Set up conda environment
+    - name: Setup conda environment
       uses: conda-incubator/setup-miniconda@v3.0.3
       with:
         auto-update-conda: true
+        activate-environment: ci-env
+        environment-file: build/environment.yml
         python-version: ${{ matrix.python-version }}
-    - name: Install python packages
-      run: conda install --yes cartopy matplotlib netcdf4
+        auto-activate-base: false
     # NetCDF C and FORTRAN libraries
     - name: Install NetCDF library
       run: |

--- a/build/Makefile.conf
+++ b/build/Makefile.conf
@@ -1,6 +1,6 @@
 #F90      = gfortran
 #F90FLAGS = -O3 -ffree-line-length-none -fcheck=bounds -finit-real=nan
 
-F90_LIB     = /home/runner/netcdf-fortran
-NC_INC      = -I$(F90_LIB)/include
-NC_LIB      = -L$(F90_LIB)/lib
+F90_LIB     = ${NFHOME}
+NC_INC      = -I$(NFHOME)/include
+NC_LIB      = -L$(NFHOME)/lib

--- a/build/environment.yml
+++ b/build/environment.yml
@@ -1,0 +1,8 @@
+name: ci-env
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - cartopy
+  - matplotlib
+  - netcdf4

--- a/driver/data/outputs/UKMO/cosp2_output.um_global.ifort.kgo.v002.nc.md5
+++ b/driver/data/outputs/UKMO/cosp2_output.um_global.ifort.kgo.v002.nc.md5
@@ -1,0 +1,1 @@
+c8c21f8d4cf8de96e7e2db0bc93d0f3e  cosp2_output.um_global.ifort.kgo.v002.nc

--- a/driver/data/outputs/UKMO/cosp2_output.um_global.ifx.kgo.v002.nc.md5
+++ b/driver/data/outputs/UKMO/cosp2_output.um_global.ifx.kgo.v002.nc.md5
@@ -1,0 +1,1 @@
+bed330b229dbdd674a11e0f8c65f011f  cosp2_output.um_global.ifx.kgo.v002.nc

--- a/driver/data/outputs/UKMO/cosp2_output_um.ifort.kgo.v002.nc.md5
+++ b/driver/data/outputs/UKMO/cosp2_output_um.ifort.kgo.v002.nc.md5
@@ -1,0 +1,1 @@
+fb0ba88dc9df95bf67d06442c3a85394  cosp2_output_um.ifort.kgo.v002.nc

--- a/driver/data/outputs/UKMO/cosp2_output_um.ifx.kgo.v002.nc.md5
+++ b/driver/data/outputs/UKMO/cosp2_output_um.ifx.kgo.v002.nc.md5
@@ -1,0 +1,1 @@
+23b30d93bafd5942c7b70f034885eeec  cosp2_output_um.ifx.kgo.v002.nc


### PR DESCRIPTION
This PR split the continuous integration tests into two workflows, one for the gfortran compilers and a second one for containerized ifort compilers. This PR also creates KGOs for ifort and ifx that allows for strict regression tests (as it was done for gfortran compilers).
This is an interim step that fixes the CI workflows. Support for nvidia compiler will be added in a separate PR because that compiler throws a runtime error that needs to be investigated.