### PR TITLE
Upload multiple artifacts when CI fails

### DIFF
--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -137,4 +137,4 @@ jobs:
       uses: actions/upload-artifact@v4.3.1
       with:
         name: outputs.${{ matrix.compiler }}.UKMO.tgz
-        path: driver/data/outputs/UKMO/outputs.UKMO.tgz
+        path: driver/data/outputs/UKMO/outputs.${{ matrix.compiler }}.UKMO.tgz

--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -133,7 +133,7 @@ jobs:
     # Make output files available if any test fails
     ###############################################################################
     - name: Upload output file if test fails
-      if: success()
+      if: failure()
       uses: actions/upload-artifact@v4.3.1
       with:
         name: outputs.${{ matrix.compiler }}.UKMO.tgz

--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -25,7 +25,7 @@ jobs:
         - compiler: ifx
           image: ghcr.io/earth-system-radiation/rte-rrtmgp-ci:oneapi
         # Common variables
-        - kgo_version: v001
+        - kgo_version: v002
     container:
       image: ${{ matrix.image }}
     env:
@@ -133,7 +133,7 @@ jobs:
     # Make output files available if any test fails
     ###############################################################################
     - name: Upload output file if test fails
-      if: failure()
+      if: success()
       uses: actions/upload-artifact@v4.3.1
       with:
         name: outputs.${{ matrix.compiler }}.UKMO.tgz

--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -24,6 +24,8 @@ jobs:
           image: ghcr.io/earth-system-radiation/rte-rrtmgp-ci:oneapi
         - compiler: ifx
           image: ghcr.io/earth-system-radiation/rte-rrtmgp-ci:oneapi
+        # Common variables
+        - kgo_version: v001
     container:
       image: ${{ matrix.image }}
     env:
@@ -35,7 +37,7 @@ jobs:
       # KGO tests variables
       ATOL: 0.0
       RTOL: 0.0
-      KGO_VERSION: v002
+      KGO_VERSION: ${{ matrix.kgo_version }}
       GDKGO1: ${{ matrix.gdkgo1 }}
       GDKGO2: ${{ matrix.gdkgo2 }}
     steps:
@@ -123,7 +125,7 @@ jobs:
           python plot_test_outputs.py --tst_file=$TST_MLEV
         fi
         cd data/outputs/UKMO
-        tar --ignore-failed-read -czf outputs.UKMO.tgz cosp2_output.um_global.nc \
+        tar --ignore-failed-read -czf outputs.${{ matrix.compiler }}.UKMO.tgz cosp2_output.um_global.nc \
           cosp2_output_um.nc cosp2_output.um_global_model_levels.nc *.png \
           cosp2_output.um_global.out
         ls -lh
@@ -134,5 +136,5 @@ jobs:
       if: failure()
       uses: actions/upload-artifact@v4.3.1
       with:
-        name: outputs.UKMO.tgz
+        name: outputs.${{ matrix.compiler }}.UKMO.tgz
         path: driver/data/outputs/UKMO/outputs.UKMO.tgz

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -41,7 +41,7 @@ jobs:
         python-version: [3.11]
         include:
           - compiler_short_name: gfortran
-          - kgo_version: v001
+          - kgo_version: v002
     defaults:
       run:
         shell: bash -el {0}

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -39,6 +39,9 @@ jobs:
       matrix:
         compiler: [gfortran-10, gfortran-11, gfortran-12]
         python-version: [3.11]
+        include:
+          - compiler_short_name: gfortran
+          - kgo_version: v001
     defaults:
       run:
         shell: bash -el {0}
@@ -49,11 +52,11 @@ jobs:
       NFHOME: /usr
       ATOL: 0.0
       RTOL: 0.0
-      KGO_VERSION: v002
+      KGO_VERSION: ${{ matrix.kgo_version }}
       GDKGO1: https://docs.google.com/uc?export=download&id=11dKcIL3EQr7s6jbo4f9GsoW0SufesGbq
       GDKGO2: https://docs.google.com/uc?export=download&id=1s5Ha6Hqnv_hWbRUs8KQpJ4Lxy8uvJDar
       GDKGO3: https://docs.google.com/uc?export=download&id=1kY1lRgzd0UhDiQef2u-VgTQql_iut3U2
-      F90_SHORT_NAME: gfortran
+      F90_SHORT_NAME: ${{ matrix.compiler_short_name }}
     # Sequence of tasks that will be executed as part of the job
     steps:
     ###############################################################################
@@ -176,7 +179,7 @@ jobs:
           python plot_test_outputs.py --tst_file=$TST_MLEV
         fi
         cd data/outputs/UKMO
-        tar --ignore-failed-read -czf outputs.UKMO.tgz cosp2_output.um_global.nc \
+        tar --ignore-failed-read -czf outputs.${{ matrix.compiler }}.UKMO.tgz cosp2_output.um_global.nc \
           cosp2_output_um.nc cosp2_output.um_global_model_levels.nc *.png \
           cosp2_output.um_global.out
         ls -lh
@@ -187,5 +190,5 @@ jobs:
       if: failure()
       uses: actions/upload-artifact@v4.3.1
       with:
-        name: outputs.UKMO.tgz
-        path: driver/data/outputs/UKMO/outputs.UKMO.tgz
+        name: outputs.${{ matrix.compiler }}.UKMO.tgz
+        path: driver/data/outputs/UKMO/outputs.${{ matrix.compiler }}.UKMO.tgz


### PR DESCRIPTION
Currently, the CI tests only upload one artifact. The second test fails to upload because the artifact name is the same. This change fixes that by uploading one artifact per compiler. This will simplify the review of changes that modify the KGOs.