### PR TITLE
Make rcfg_cloudsat a HEAP variable

### DIFF
--- a/driver/src/cosp2_test.f90
+++ b/driver/src/cosp2_test.f90
@@ -996,6 +996,7 @@ contains
                 y%ss_alb(npoints,         ncolumns,nlevels))
     endif
     
+    allocate (y%rcfg_cloudsat)
 
   end subroutine construct_cospIN
   

--- a/src/cosp.F90
+++ b/src/cosp.F90
@@ -166,7 +166,7 @@ MODULE MOD_COSP
           tautot_S_liq,        & ! Parasol Liquid water optical thickness, from TOA to SFC
           tautot_S_ice,        & ! Parasol Ice water optical thickness, from TOA to SFC
           fracPrecipIce          ! Fraction of precipitation which is frozen (1).
-     type(radar_cfg) :: &
+     type(radar_cfg), allocatable :: &
           rcfg_cloudsat          ! Radar configuration information (CLOUDSAT)
   end type cosp_optical_inputs
 


### PR DESCRIPTION
The rcfg_cloudsat variable can be large. If the cospIN object is on the stack, this can cause lots of stack memory, which can fail unless ppl run `ulimit -s unlimited` first. In particular, cospIN was 28MB, while the common stack size is 8MB.