### PR TITLE
Update intel KGOs to v004.

### DIFF
--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -12,20 +12,20 @@ jobs:
         # Flags and KGOs for Intel Fortran Compiler Classic
         - compiler: ifort
           fcflags: -m64 -g -traceback -heap-arrays -assume realloc_lhs -extend-source 132 -check bounds,uninit,pointers,stack -stand f08
-          gdkgo1: https://docs.google.com/uc?export=download&id=1eyRCT9e7j7SKsKhbfJBuwBoN5DlsrW7L
-          gdkgo2: https://docs.google.com/uc?export=download&id=1uTffyCdWLPvRHDkVtZZiBfc3spbk4_Tf
+          gdkgo1: https://docs.google.com/uc?export=download&id=1dva4lq4ZXciTiuOvGgA8OUJKihbGQ90K
+          gdkgo2: https://docs.google.com/uc?export=download&id=1ns0OtWU5jVnu1IEBfBN-tlTkq2PTrcvC
         # Flags and KGOs for Intel Fortran Compiler
         - compiler: ifx
           fcflags: -debug -traceback -O0 -heap-arrays -assume realloc_lhs -extend-source 132 -stand f08
-          gdkgo1: https://docs.google.com/uc?export=download&id=1VrPkQmDpt6otch-tsaka-62tiMDuJNz_
-          gdkgo2: https://docs.google.com/uc?export=download&id=1m6JdHlSAMmK8zT-X3pfxSORPJURiITkQ
+          gdkgo1: https://docs.google.com/uc?export=download&id=1WzFsoqi0EZfsyyh203QXmUQTIh5tBm9b
+          gdkgo2: https://docs.google.com/uc?export=download&id=1ezYqG-jfZ6i9bRgKOWUyBiQlMhtncpKj
         # Set container images
         - compiler: ifort
           image: ghcr.io/earth-system-radiation/rte-rrtmgp-ci:oneapi
         - compiler: ifx
           image: ghcr.io/earth-system-radiation/rte-rrtmgp-ci:oneapi
         # Common variables
-        - kgo_version: v003
+        - kgo_version: v004
     container:
       image: ${{ matrix.image }}
     env:

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,4 @@ driver/data/inputs/UKMO/*_global.nc
 driver/data/outputs/UKMO/*kgo.v*.nc
 driver/data/outputs/UKMO/*.nc
 !driver/data/outputs/cosp2_output_um.gfortran.kgo.nc
-driver/data/outputs/UKMO/*md5
 driver/data/outputs/UKMO/*.out

--- a/driver/data/outputs/UKMO/cosp2_output.um_global.ifort.kgo.v004.nc.md5
+++ b/driver/data/outputs/UKMO/cosp2_output.um_global.ifort.kgo.v004.nc.md5
@@ -1,0 +1,1 @@
+d22e708b28bab19dae4c769fe7d33e40  cosp2_output.um_global.ifort.kgo.v004.nc

--- a/driver/data/outputs/UKMO/cosp2_output.um_global.ifx.kgo.v004.nc.md5
+++ b/driver/data/outputs/UKMO/cosp2_output.um_global.ifx.kgo.v004.nc.md5
@@ -1,0 +1,1 @@
+aa0b47fa93e5d96d2a225a2f50348d30  cosp2_output.um_global.ifx.kgo.v004.nc

--- a/driver/data/outputs/UKMO/cosp2_output_um.ifort.kgo.v004.nc.md5
+++ b/driver/data/outputs/UKMO/cosp2_output_um.ifort.kgo.v004.nc.md5
@@ -1,0 +1,1 @@
+0e75e4adac759d797d1264d76490fa9d  cosp2_output_um.ifort.kgo.v004.nc

--- a/driver/data/outputs/UKMO/cosp2_output_um.ifx.kgo.v004.nc.md5
+++ b/driver/data/outputs/UKMO/cosp2_output_um.ifx.kgo.v004.nc.md5
@@ -1,0 +1,1 @@
+d88395d3962b9c25a15d94b13f6db42d  cosp2_output_um.ifx.kgo.v004.nc


### PR DESCRIPTION
Integration tests for intel compilers fail due to compiler upgrades or other changes in external dependencies (https://github.com/CFMIP/COSPv2.0/actions/runs/10736182713). This PR updates the KGOs,