### PR TITLE
Fix a valgrind uninitialized conditional error in cosp

### DIFF
--- a/src/cosp.F90
+++ b/src/cosp.F90
@@ -499,7 +499,7 @@ CONTAINS
        Lrttov_column    = .true.
 
     ! Set flag to deallocate rttov types (only done on final call to simulator)
-    if (size(cospOUT%isccp_meantb) .eq. stop_idx) lrttov_cleanUp = .true.
+    if (associated(cospOUT%isccp_meantb) .and. size(cospOUT%isccp_meantb) .eq. stop_idx) lrttov_cleanUp = .true.
 
     ! ISCCP column
     if (associated(cospOUT%isccp_fq)                                       .or.          &


### PR DESCRIPTION
The modified line was causing this error:
==19971== Conditional jump or move depends on uninitialised value(s)
==19971==    at 0xA47583: __mod_cosp_MOD_cosp_simulator (cosp.F90:502)

... when cospOUT%isccp_meantb is not allocated. I noticed all surrounding accesses of members of cospOUT were guarded by association checks, so I added that check.