### PR TITLE
Update effective radius bin ranges for new MODIS ice-cloud CER-CWP joint histograms

### DIFF
--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -12,20 +12,20 @@ jobs:
         # Flags and KGOs for Intel Fortran Compiler Classic
         - compiler: ifort
           fcflags: -m64 -g -traceback -heap-arrays -assume realloc_lhs -extend-source 132 -check bounds,uninit,pointers,stack -stand f08
-          gdkgo1: https://docs.google.com/uc?export=download&id=1dva4lq4ZXciTiuOvGgA8OUJKihbGQ90K
-          gdkgo2: https://docs.google.com/uc?export=download&id=1ns0OtWU5jVnu1IEBfBN-tlTkq2PTrcvC
+          gdkgo1: https://docs.google.com/uc?export=download&id=1R6uvtWno-bhdgxACCwdcaRNXs9l5_G4w
+          gdkgo2: https://docs.google.com/uc?export=download&id=1bVU1_dx6hXcV_fHX2cLUn-D03T-Hij8z
         # Flags and KGOs for Intel Fortran Compiler
         - compiler: ifx
           fcflags: -debug -traceback -O0 -heap-arrays -assume realloc_lhs -extend-source 132 -stand f08
-          gdkgo1: https://docs.google.com/uc?export=download&id=1WzFsoqi0EZfsyyh203QXmUQTIh5tBm9b
-          gdkgo2: https://docs.google.com/uc?export=download&id=1ezYqG-jfZ6i9bRgKOWUyBiQlMhtncpKj
+          gdkgo1: https://docs.google.com/uc?export=download&id=1CLPJ1ikAcGBEiZ3WAGqL-zpaPIgC__po
+          gdkgo2: https://docs.google.com/uc?export=download&id=1JOrLFbt0BYgpD0h6A3tsoRD4iTJ4jDvZ
         # Set container images
         - compiler: ifort
           image: ghcr.io/earth-system-radiation/rte-rrtmgp-ci:oneapi
         - compiler: ifx
           image: ghcr.io/earth-system-radiation/rte-rrtmgp-ci:oneapi
         # Common variables
-        - kgo_version: v004
+        - kgo_version: v005
     defaults:
       run:
         shell: bash -el {0}

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -41,7 +41,7 @@ jobs:
         python-version: [3.11]
         include:
           - compiler_short_name: gfortran
-          - kgo_version: v003
+          - kgo_version: v004
     defaults:
       run:
         shell: bash -el {0}
@@ -53,9 +53,12 @@ jobs:
       ATOL: 0.0
       RTOL: 0.0
       KGO_VERSION: ${{ matrix.kgo_version }}
-      GDKGO1: https://docs.google.com/uc?export=download&id=1oQBJGFg0F8k-LhRGsCYn-qWzmMMVfQ6K
-      GDKGO2: https://docs.google.com/uc?export=download&id=1b7qwJWqDzoZGcIP0qyUprTV_LErCGpT6
-      GDKGO3: https://docs.google.com/uc?export=download&id=1NvTo3bYaGpz-FUpZ4jta_kRzA04xTCsn
+      # KGO1 is cosp2_output_um.gfortran.kgo.vNNN.nc.gz
+      GDKGO1: https://docs.google.com/uc?export=download&id=1kC9RViPBdAsGcOivpYXxs3hHJ11Kv8IN
+      # KGO2 is cosp2_output.um_global.gfortran.kgo.vNNN.nc.gz
+      GDKGO2: https://docs.google.com/uc?export=download&id=1X_oOzvY2lf-kyAR-D1E6JfuefkGg1idn
+      # KGO3 is cosp2_output.um_global_model_levels.gfortran.kgo.vNNN.nc.gz
+      GDKGO3: https://docs.google.com/uc?export=download&id=1c14qBf9VwYJWYVGCu-Cw35F-qqHx0mSg
       F90_SHORT_NAME: ${{ matrix.compiler_short_name }}
     # Sequence of tasks that will be executed as part of the job
     steps:

--- a/build/Makefile.conf
+++ b/build/Makefile.conf
@@ -1,5 +1,5 @@
-#F90      = gfortran
-#F90FLAGS = -O3 -ffree-line-length-none -fcheck=bounds -finit-real=nan
+F90      = gfortran
+F90FLAGS = -O3 -ffree-line-length-none -fcheck=bounds -finit-real=nan -I/home/bmduran/.conda/envs/ci-env/include -I/home/bmduran/.conda/envs/ci-env/lib -L/home/bmduran/.conda/envs/ci-env/lib
 
 F90_LIB     = ${NFHOME}
 NC_INC      = -I$(NFHOME)/include

--- a/build/Makefile.conf
+++ b/build/Makefile.conf
@@ -1,5 +1,5 @@
-F90      = gfortran
-F90FLAGS = -O3 -ffree-line-length-none -fcheck=bounds -finit-real=nan -I/home/bmduran/.conda/envs/ci-env/include -I/home/bmduran/.conda/envs/ci-env/lib -L/home/bmduran/.conda/envs/ci-env/lib
+#F90      = gfortran
+#F90FLAGS = -O3 -ffree-line-length-none -fcheck=bounds -finit-real=nan
 
 F90_LIB     = ${NFHOME}
 NC_INC      = -I$(NFHOME)/include

--- a/driver/plot_test_outputs.py
+++ b/driver/plot_test_outputs.py
@@ -112,11 +112,11 @@ def collapse_dimensions_for_plotting(longitude, latitude, vname, vx, vd, dims):
             yticks = y
             ylabel = 'Cloud Top Height (m)'
         if vd['yaxis_type'] == 'REICE_MODIS':
-            yticks_labels =  ('5', '10', '20', '30', '40','50', '60', '10000')
+            yticks_labels =  ('0','5', '10', '20', '30', '40','50', '60', '10000')
             yticks = y
             ylabel = 'Ice particle size (micron)'
         if vd['yaxis_type'] == 'RELIQ_MODIS':
-            yticks_labels = ('4', '8', '10', '12.5', '15', '20', '30')
+            yticks_labels = ('0','4', '8', '10', '12.5', '15', '20', '30', '10000')
             yticks = y
             ylabel = 'Liquid particle size (micron)'
         if vd['yaxis_type'] == 'levStat':

--- a/driver/plot_test_outputs.py
+++ b/driver/plot_test_outputs.py
@@ -112,11 +112,11 @@ def collapse_dimensions_for_plotting(longitude, latitude, vname, vx, vd, dims):
             yticks = y
             ylabel = 'Cloud Top Height (m)'
         if vd['yaxis_type'] == 'REICE_MODIS':
-            yticks_labels =  ('0', '10', '20', '30', '40', '60', '90')
+            yticks_labels =  ('5', '10', '20', '30', '40','50', '60', '10000')
             yticks = y
             ylabel = 'Ice particle size (micron)'
         if vd['yaxis_type'] == 'RELIQ_MODIS':
-            yticks_labels = ('0', '8', '10', '13', '15', '20', '30')
+            yticks_labels = ('4', '8', '10', '12.5', '15', '20', '30')
             yticks = y
             ylabel = 'Liquid particle size (micron)'
         if vd['yaxis_type'] == 'levStat':

--- a/src/cosp_config.F90
+++ b/src/cosp_config.F90
@@ -130,16 +130,15 @@ MODULE MOD_COSP_CONFIG
     ! Liquid and Ice particle bins for MODIS joint histogram of optical-depth and particle
     ! size
     ! Bin edges match Pincus et al. 2023 observational data (doi:10.5194/essd-15-2483-2023)
-    ! Additional ReffICE bin (60-90 microns) to capture clouds with CER > 60 microns 
-    ! simulated by GCMs
+    ! Additional Re bins to capture all simulated clouds
     integer :: i,j
     integer,parameter :: &
-         nReffLiq = 6, & ! Number of ReffLiq bins for tau/ReffLiq and LWP/ReffLiq joint-histogram
-         nReffIce = 7 ! Number of ReffIce bins for tau/ReffICE and IWP/ReffIce joint-histogram
+         nReffLiq = 8, & ! Number of ReffLiq bins for tau/ReffLiq and LWP/ReffLiq joint-histogram
+         nReffIce = 8 ! Number of ReffIce bins for tau/ReffICE and IWP/ReffIce joint-histogram
     real(wp),parameter,dimension(nReffLiq+1) :: &
-         reffLIQ_binBounds = (/4.0e-6, 8e-6, 1.0e-5, 1.25e-5, 1.5e-5, 2.0e-5, 3.0e-5/)
+         reffLIQ_binBounds = (/0.0, 4.0e-6, 8e-6, 1.0e-5, 1.25e-5, 1.5e-5, 2.0e-5, 3.0e-5, 1.0e-2/)
     real(wp),parameter,dimension(nReffIce+1) :: &
-         reffICE_binBounds = (/5.0e-6, 1.0e-5, 2.0e-5, 3.0e-5, 4.0e-5, 5.0e-5, 6.0e-5, 1.0e-2/)
+         reffICE_binBounds = (/0.0,5.0e-6, 1.0e-5, 2.0e-5, 3.0e-5, 4.0e-5, 5.0e-5, 6.0e-5, 1.0e-2/)
     real(wp),parameter,dimension(2,nReffICE) :: &
          reffICE_binEdges = reshape(source=(/reffICE_binBounds(1),((reffICE_binBounds(k),  &
                                     l=1,2),k=2,nReffICE),reffICE_binBounds(nReffICE+1)/),  &

--- a/src/cosp_config.F90
+++ b/src/cosp_config.F90
@@ -139,7 +139,7 @@ MODULE MOD_COSP_CONFIG
     real(wp),parameter,dimension(nReffLiq+1) :: &
          reffLIQ_binBounds = (/4.0e-6, 8e-6, 1.0e-5, 1.25e-5, 1.5e-5, 2.0e-5, 3.0e-5/)
     real(wp),parameter,dimension(nReffIce+1) :: &
-         reffICE_binBounds = (/5.0e-6, 1.0e-5, 2.0e-5, 3.0e-5, 4.0e-5, 5.0e-5, 6.0e-5/, 9.0e-5)
+         reffICE_binBounds = (/5.0e-6, 1.0e-5, 2.0e-5, 3.0e-5, 4.0e-5, 5.0e-5, 6.0e-5/, 1.0e-2)
     real(wp),parameter,dimension(2,nReffICE) :: &
          reffICE_binEdges = reshape(source=(/reffICE_binBounds(1),((reffICE_binBounds(k),  &
                                     l=1,2),k=2,nReffICE),reffICE_binBounds(nReffICE+1)/),  &

--- a/src/cosp_config.F90
+++ b/src/cosp_config.F90
@@ -130,11 +130,12 @@ MODULE MOD_COSP_CONFIG
     ! Liquid and Ice particle bins for MODIS joint histogram of optical-depth and particle
     ! size
     ! Bin edges match Pincus et al. 2023 observational data (doi:10.5194/essd-15-2483-2023)
+    ! Additional ReffICE bin (60-90 microns) to capture clouds with CER > 60 microns 
+    ! simulated by GCMs
     integer :: i,j
     integer,parameter :: &
          nReffLiq = 6, & ! Number of ReffLiq bins for tau/ReffLiq and LWP/ReffLiq joint-histogram
-!         nReffIce = 6    ! Number of ReffIce bins for tau/ReffICE and IWP/ReffIce joint-histogram
-         nReffIce = 7
+         nReffIce = 7 ! Number of ReffIce bins for tau/ReffICE and IWP/ReffIce joint-histogram
     real(wp),parameter,dimension(nReffLiq+1) :: &
          reffLIQ_binBounds = (/4.0e-6, 8e-6, 1.0e-5, 1.25e-5, 1.5e-5, 2.0e-5, 3.0e-5/)
     real(wp),parameter,dimension(nReffIce+1) :: &

--- a/src/cosp_config.F90
+++ b/src/cosp_config.F90
@@ -139,7 +139,7 @@ MODULE MOD_COSP_CONFIG
     real(wp),parameter,dimension(nReffLiq+1) :: &
          reffLIQ_binBounds = (/4.0e-6, 8e-6, 1.0e-5, 1.25e-5, 1.5e-5, 2.0e-5, 3.0e-5/)
     real(wp),parameter,dimension(nReffIce+1) :: &
-         reffICE_binBounds = (/5.0e-6, 1.0e-5, 2.0e-5, 3.0e-5, 4.0e-5, 5.0e-5, 6.0e-5/, 1.0e-2)
+         reffICE_binBounds = (/5.0e-6, 1.0e-5, 2.0e-5, 3.0e-5, 4.0e-5, 5.0e-5, 6.0e-5, 1.0e-2/)
     real(wp),parameter,dimension(2,nReffICE) :: &
          reffICE_binEdges = reshape(source=(/reffICE_binBounds(1),((reffICE_binBounds(k),  &
                                     l=1,2),k=2,nReffICE),reffICE_binBounds(nReffICE+1)/),  &

--- a/src/cosp_config.F90
+++ b/src/cosp_config.F90
@@ -133,11 +133,12 @@ MODULE MOD_COSP_CONFIG
     integer :: i,j
     integer,parameter :: &
          nReffLiq = 6, & ! Number of ReffLiq bins for tau/ReffLiq and LWP/ReffLiq joint-histogram
-         nReffIce = 6    ! Number of ReffIce bins for tau/ReffICE and IWP/ReffIce joint-histogram
+!         nReffIce = 6    ! Number of ReffIce bins for tau/ReffICE and IWP/ReffIce joint-histogram
+         nReffIce = 7
     real(wp),parameter,dimension(nReffLiq+1) :: &
          reffLIQ_binBounds = (/4.0e-6, 8e-6, 1.0e-5, 1.25e-5, 1.5e-5, 2.0e-5, 3.0e-5/)
     real(wp),parameter,dimension(nReffIce+1) :: &
-         reffICE_binBounds = (/5.0e-6, 1.0e-5, 2.0e-5, 3.0e-5, 4.0e-5, 5.0e-5, 6.0e-5/)
+         reffICE_binBounds = (/5.0e-6, 1.0e-5, 2.0e-5, 3.0e-5, 4.0e-5, 5.0e-5, 6.0e-5/, 9.0e-5)
     real(wp),parameter,dimension(2,nReffICE) :: &
          reffICE_binEdges = reshape(source=(/reffICE_binBounds(1),((reffICE_binBounds(k),  &
                                     l=1,2),k=2,nReffICE),reffICE_binBounds(nReffICE+1)/),  &


### PR DESCRIPTION
We have adjusted `cosp_config.F90` to  add a _new effective radius bin_ for the MODIS ice-cloud CER-CWP joint histogram. External testing has shown that some GCMs simulate ice-clouds with CER > 60 microns, which are not accounted for given the current bin limits.

_Changes:_
(1) A new CER bin has been added **(60 to 10000 microns).**

The proposed range of 60-10000 microns is intended to capture all of the ice clouds simulated by GCMs that have CER > 60 microns. We modified this range from our initial proposal of 60-90 microns as @klein21 correctly noted that there was no justification for imposing an upper limit on particle size.