### PR TITLE
Bugfix in compare_to_kgo

### DIFF
--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -12,20 +12,20 @@ jobs:
         # Flags and KGOs for Intel Fortran Compiler Classic
         - compiler: ifort
           fcflags: -m64 -g -traceback -heap-arrays -assume realloc_lhs -extend-source 132 -check bounds,uninit,pointers,stack -stand f08
-          gdkgo1: https://docs.google.com/uc?export=download&id=1dva4lq4ZXciTiuOvGgA8OUJKihbGQ90K
-          gdkgo2: https://docs.google.com/uc?export=download&id=1ns0OtWU5jVnu1IEBfBN-tlTkq2PTrcvC
+          gdkgo1: https://docs.google.com/uc?export=download&id=1R6uvtWno-bhdgxACCwdcaRNXs9l5_G4w
+          gdkgo2: https://docs.google.com/uc?export=download&id=1bVU1_dx6hXcV_fHX2cLUn-D03T-Hij8z
         # Flags and KGOs for Intel Fortran Compiler
         - compiler: ifx
           fcflags: -debug -traceback -O0 -heap-arrays -assume realloc_lhs -extend-source 132 -stand f08
-          gdkgo1: https://docs.google.com/uc?export=download&id=1WzFsoqi0EZfsyyh203QXmUQTIh5tBm9b
-          gdkgo2: https://docs.google.com/uc?export=download&id=1ezYqG-jfZ6i9bRgKOWUyBiQlMhtncpKj
+          gdkgo1: https://docs.google.com/uc?export=download&id=1CLPJ1ikAcGBEiZ3WAGqL-zpaPIgC__po
+          gdkgo2: https://docs.google.com/uc?export=download&id=1JOrLFbt0BYgpD0h6A3tsoRD4iTJ4jDvZ
         # Set container images
         - compiler: ifort
           image: ghcr.io/earth-system-radiation/rte-rrtmgp-ci:oneapi
         - compiler: ifx
           image: ghcr.io/earth-system-radiation/rte-rrtmgp-ci:oneapi
         # Common variables
-        - kgo_version: v004
+        - kgo_version: v005
     defaults:
       run:
         shell: bash -el {0}

--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -84,6 +84,7 @@ jobs:
         cd ${GITHUB_WORKSPACE}
         OUTPATH=driver/data/outputs/UKMO/cosp2_output_um.$F90.kgo.$KGO_VERSION.nc.gz
         curl -sSfL -o $OUTPATH $GDKGO1
+        ls -l ${OUTPATH}
         gunzip ${OUTPATH}
         cd driver/data/outputs/UKMO
         # md5sum -c cosp2_output_um.${F90}.kgo.$KGO_VERSION.nc.md5

--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -12,20 +12,20 @@ jobs:
         # Flags and KGOs for Intel Fortran Compiler Classic
         - compiler: ifort
           fcflags: -m64 -g -traceback -heap-arrays -assume realloc_lhs -extend-source 132 -check bounds,uninit,pointers,stack -stand f08
-          gdkgo1: https://docs.google.com/uc?export=download&id=1R6uvtWno-bhdgxACCwdcaRNXs9l5_G4w
-          gdkgo2: https://docs.google.com/uc?export=download&id=1bVU1_dx6hXcV_fHX2cLUn-D03T-Hij8z
+          gdkgo1: https://docs.google.com/uc?export=download&id=1dva4lq4ZXciTiuOvGgA8OUJKihbGQ90K
+          gdkgo2: https://docs.google.com/uc?export=download&id=1ns0OtWU5jVnu1IEBfBN-tlTkq2PTrcvC
         # Flags and KGOs for Intel Fortran Compiler
         - compiler: ifx
           fcflags: -debug -traceback -O0 -heap-arrays -assume realloc_lhs -extend-source 132 -stand f08
-          gdkgo1: https://docs.google.com/uc?export=download&id=1CLPJ1ikAcGBEiZ3WAGqL-zpaPIgC__po
-          gdkgo2: https://docs.google.com/uc?export=download&id=1JOrLFbt0BYgpD0h6A3tsoRD4iTJ4jDvZ
+          gdkgo1: https://docs.google.com/uc?export=download&id=1WzFsoqi0EZfsyyh203QXmUQTIh5tBm9b
+          gdkgo2: https://docs.google.com/uc?export=download&id=1ezYqG-jfZ6i9bRgKOWUyBiQlMhtncpKj
         # Set container images
         - compiler: ifort
           image: ghcr.io/earth-system-radiation/rte-rrtmgp-ci:oneapi
         - compiler: ifx
           image: ghcr.io/earth-system-radiation/rte-rrtmgp-ci:oneapi
         # Common variables
-        - kgo_version: v005
+        - kgo_version: v004
     defaults:
       run:
         shell: bash -el {0}

--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -117,6 +117,7 @@ jobs:
         python compare_to_kgo.py ${KGO} ${TST} --atol=${ATOL} --rtol=${RTOL} --stats_file=${STATS}
     # 2. UM global snapshot.
     - name: UM global against known good output (KGO)
+      if: always()
       run: |
         cd driver
         KGO=data/outputs/UKMO/cosp2_output.um_global.${{ matrix.compiler }}.kgo.$KGO_VERSION.nc

--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -131,15 +131,13 @@ jobs:
       if: failure()
       run: |
         cd driver
-        DRIVER_DIR=$PWD
+        if [[ -e data/outputs/UKMO/cosp2_output.um_global.nc ]]; then
+          python plot_test_outputs.py
+        fi
         cd data/outputs/UKMO
         tar --ignore-failed-read -czf outputs.${{ matrix.compiler }}.UKMO.tgz cosp2_output.um_global.nc \
           cosp2_output_um.nc *.png cosp2_output*.${{ matrix.compiler }}.out
         ls -lh
-        cd $DRIVER_DIR
-        if [[ -e data/outputs/UKMO/cosp2_output.um_global.nc ]]; then
-          python plot_test_outputs.py
-        fi
     ###############################################################################
     # Make output files available if any test fails
     ###############################################################################

--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -131,13 +131,15 @@ jobs:
       if: failure()
       run: |
         cd driver
-        if [[ -e data/outputs/UKMO/cosp2_output.um_global.nc ]]; then
-          python plot_test_outputs.py
-        fi
+        DRIVER_DIR=$PWD
         cd data/outputs/UKMO
         tar --ignore-failed-read -czf outputs.${{ matrix.compiler }}.UKMO.tgz cosp2_output.um_global.nc \
           cosp2_output_um.nc *.png cosp2_output*.${{ matrix.compiler }}.out
         ls -lh
+        cd $DRIVER_DIR
+        if [[ -e data/outputs/UKMO/cosp2_output.um_global.nc ]]; then
+          python plot_test_outputs.py
+        fi
     ###############################################################################
     # Make output files available if any test fails
     ###############################################################################

--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -84,7 +84,6 @@ jobs:
         cd ${GITHUB_WORKSPACE}
         OUTPATH=driver/data/outputs/UKMO/cosp2_output_um.$F90.kgo.$KGO_VERSION.nc.gz
         curl -sSfL -o $OUTPATH $GDKGO1
-        ls -l ${OUTPATH}
         gunzip ${OUTPATH}
         cd driver/data/outputs/UKMO
         # md5sum -c cosp2_output_um.${F90}.kgo.$KGO_VERSION.nc.md5

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -41,7 +41,7 @@ jobs:
         python-version: [3.11]
         include:
           - compiler_short_name: gfortran
-          - kgo_version: v003
+          - kgo_version: v004
     defaults:
       run:
         shell: bash -el {0}
@@ -53,9 +53,12 @@ jobs:
       ATOL: 0.0
       RTOL: 0.0
       KGO_VERSION: ${{ matrix.kgo_version }}
-      GDKGO1: https://docs.google.com/uc?export=download&id=1oQBJGFg0F8k-LhRGsCYn-qWzmMMVfQ6K
-      GDKGO2: https://docs.google.com/uc?export=download&id=1b7qwJWqDzoZGcIP0qyUprTV_LErCGpT6
-      GDKGO3: https://docs.google.com/uc?export=download&id=1NvTo3bYaGpz-FUpZ4jta_kRzA04xTCsn
+      # KGO1 is cosp2_output_um.gfortran.kgo.vNNN.nc.gz
+      GDKGO1: https://docs.google.com/uc?export=download&id=1kC9RViPBdAsGcOivpYXxs3hHJ11Kv8IN
+      # KGO2 is cosp2_output.um_global.gfortran.kgo.vNNN.nc.gz
+      GDKGO2: https://docs.google.com/uc?export=download&id=1X_oOzvY2lf-kyAR-D1E6JfuefkGg1idn
+      # KGO3 is cosp2_output.um_global_model_levels.gfortran.kgo.vNNN.nc.gz
+      GDKGO3: https://docs.google.com/uc?export=download&id=1c14qBf9VwYJWYVGCu-Cw35F-qqHx0mSg
       F90_SHORT_NAME: ${{ matrix.compiler_short_name }}
     # Sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -170,19 +170,19 @@ jobs:
     - name: Produce plots and create tarball
       if: failure()
       run: |
+        cd data/outputs/UKMO
+        tar --ignore-failed-read -czf outputs.${{ matrix.compiler }}.UKMO.tgz cosp2_output.um_global.nc \
+          cosp2_output_um.nc cosp2_output.um_global_model_levels.nc *.png \
+          cosp2_output.um_global.out
+        ls -lh
         TST_MLEV=data/outputs/UKMO/cosp2_output.um_global_model_levels.nc
-        cd driver
+        cd ~/driver
         if [[ -e data/outputs/UKMO/cosp2_output.um_global.nc ]]; then
           python plot_test_outputs.py
         fi
         if [[ -e data/outputs/UKMO/cosp2_output.um_global_model_levels.nc ]]; then
           python plot_test_outputs.py --tst_file=$TST_MLEV
         fi
-        cd data/outputs/UKMO
-        tar --ignore-failed-read -czf outputs.${{ matrix.compiler }}.UKMO.tgz cosp2_output.um_global.nc \
-          cosp2_output_um.nc cosp2_output.um_global_model_levels.nc *.png \
-          cosp2_output.um_global.out
-        ls -lh
     ###############################################################################
     # Make output files available if any test fails
     ###############################################################################

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -151,6 +151,7 @@ jobs:
         python compare_to_kgo.py ${KGO} ${TST} --atol=${ATOL} --rtol=${RTOL}
     # 2. UM global snapshot. 
     - name: UM global against known good output (KGO)
+      if: always()
       run: |
         cd driver
         KGO=data/outputs/UKMO/cosp2_output.um_global.${F90_SHORT_NAME}.kgo.$KGO_VERSION.nc
@@ -158,11 +159,12 @@ jobs:
         python compare_to_kgo.py ${KGO} ${TST} --atol=${ATOL} --rtol=${RTOL}
     # 3. UM global snapshot. Diagnostics on model levels.
     - name: UM global on model levels against known good output (KGO)
+      if: always()
       run: |
         cd driver
         KGO=data/outputs/UKMO/cosp2_output.um_global_model_levels.${F90_SHORT_NAME}.kgo.$KGO_VERSION.nc
         TST=data/outputs/UKMO/cosp2_output.um_global_model_levels.nc
-          python compare_to_kgo.py ${KGO} ${TST} --atol=${ATOL} --rtol=${RTOL}
+        python compare_to_kgo.py ${KGO} ${TST} --atol=${ATOL} --rtol=${RTOL}
     ###############################################################################
     # Produce plots when it fails during global snapshot tests,
     # and create a tarball with outputs.

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -170,13 +170,16 @@ jobs:
     - name: Produce plots and create tarball
       if: failure()
       run: |
-        cd driver/data/outputs/UKMO
+        cd driver
+        DRIVER_DIR=$PWD
+        echo $PWD
+        cd data/outputs/UKMO
         tar --ignore-failed-read -czf outputs.${{ matrix.compiler }}.UKMO.tgz cosp2_output.um_global.nc \
           cosp2_output_um.nc cosp2_output.um_global_model_levels.nc *.png \
           cosp2_output.um_global.out
         ls -lh
         TST_MLEV=data/outputs/UKMO/cosp2_output.um_global_model_levels.nc
-        cd ~/driver
+        cd $DRIVER_DIR
         if [[ -e data/outputs/UKMO/cosp2_output.um_global.nc ]]; then
           python plot_test_outputs.py
         fi

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -170,7 +170,7 @@ jobs:
     - name: Produce plots and create tarball
       if: failure()
       run: |
-        cd data/outputs/UKMO
+        cd driver/data/outputs/UKMO
         tar --ignore-failed-read -czf outputs.${{ matrix.compiler }}.UKMO.tgz cosp2_output.um_global.nc \
           cosp2_output_um.nc cosp2_output.um_global_model_levels.nc *.png \
           cosp2_output.um_global.out

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -41,7 +41,7 @@ jobs:
         python-version: [3.11]
         include:
           - compiler_short_name: gfortran
-          - kgo_version: v004
+          - kgo_version: v003
     defaults:
       run:
         shell: bash -el {0}
@@ -53,12 +53,9 @@ jobs:
       ATOL: 0.0
       RTOL: 0.0
       KGO_VERSION: ${{ matrix.kgo_version }}
-      # KGO1 is cosp2_output_um.gfortran.kgo.vNNN.nc.gz
-      GDKGO1: https://docs.google.com/uc?export=download&id=1kC9RViPBdAsGcOivpYXxs3hHJ11Kv8IN
-      # KGO2 is cosp2_output.um_global.gfortran.kgo.vNNN.nc.gz
-      GDKGO2: https://docs.google.com/uc?export=download&id=1X_oOzvY2lf-kyAR-D1E6JfuefkGg1idn
-      # KGO3 is cosp2_output.um_global_model_levels.gfortran.kgo.vNNN.nc.gz
-      GDKGO3: https://docs.google.com/uc?export=download&id=1c14qBf9VwYJWYVGCu-Cw35F-qqHx0mSg
+      GDKGO1: https://docs.google.com/uc?export=download&id=1oQBJGFg0F8k-LhRGsCYn-qWzmMMVfQ6K
+      GDKGO2: https://docs.google.com/uc?export=download&id=1b7qwJWqDzoZGcIP0qyUprTV_LErCGpT6
+      GDKGO3: https://docs.google.com/uc?export=download&id=1NvTo3bYaGpz-FUpZ4jta_kRzA04xTCsn
       F90_SHORT_NAME: ${{ matrix.compiler_short_name }}
     # Sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -170,22 +170,19 @@ jobs:
     - name: Produce plots and create tarball
       if: failure()
       run: |
-        cd driver
-        DRIVER_DIR=$PWD
-        echo $PWD
-        cd data/outputs/UKMO
-        tar --ignore-failed-read -czf outputs.${{ matrix.compiler }}.UKMO.tgz cosp2_output.um_global.nc \
-          cosp2_output_um.nc cosp2_output.um_global_model_levels.nc *.png \
-          cosp2_output.um_global.out
-        ls -lh
         TST_MLEV=data/outputs/UKMO/cosp2_output.um_global_model_levels.nc
-        cd $DRIVER_DIR
+        cd driver
         if [[ -e data/outputs/UKMO/cosp2_output.um_global.nc ]]; then
           python plot_test_outputs.py
         fi
         if [[ -e data/outputs/UKMO/cosp2_output.um_global_model_levels.nc ]]; then
           python plot_test_outputs.py --tst_file=$TST_MLEV
         fi
+        cd data/outputs/UKMO
+        tar --ignore-failed-read -czf outputs.${{ matrix.compiler }}.UKMO.tgz cosp2_output.um_global.nc \
+          cosp2_output_um.nc cosp2_output.um_global_model_levels.nc *.png \
+          cosp2_output.um_global.out
+        ls -lh
     ###############################################################################
     # Make output files available if any test fails
     ###############################################################################

--- a/driver/compare_to_kgo.py
+++ b/driver/compare_to_kgo.py
@@ -181,8 +181,14 @@ if __name__ == '__main__':
     for vname in vlst:
         kgo = read_var(args.kgo_file, vname) # KGO
         tst = read_var(args.tst_file, vname) # test
-        summary_stats[vname] = calculate_stats(tst, kgo, 
-                                               atol=args.atol, rtol=args.rtol)
+        try:
+            summary_stats[vname] = calculate_stats(tst, kgo, 
+                                                atol=args.atol, rtol=args.rtol)
+        except:
+            summary_stats[vname].pop()
+            print(red_colour + "===== ERROR: could not compare variable "
+                  + vname + std_colour)
+            errored = True
         if summary_stats[vname]['N'] > 0: errored = True
 
     # Print summary stats

--- a/driver/compare_to_kgo.py
+++ b/driver/compare_to_kgo.py
@@ -186,7 +186,7 @@ if __name__ == '__main__':
         kgo = read_var(args.kgo_file, vname) # KGO
         tst = read_var(args.tst_file, vname) # test
         summary_stats[vname] = calculate_stats(tst, kgo, 
-                                    atol=args.atol, rtol=args.rtol)
+                                               atol=args.atol, rtol=args.rtol)
         if summary_stats[vname]['N'] > 0: errored = True
 
     # Print summary stats

--- a/driver/compare_to_kgo.py
+++ b/driver/compare_to_kgo.py
@@ -70,7 +70,11 @@ def calculate_stats(tst, kgo, atol=0.0, rtol=None):
     """
     summary_stats = {'N':0, 'AvgDiff':0.0, 'MinDiff':0.0, 'MaxDiff':0.0, 'StDev':0.0}
     # All differences
-    d = tst - kgo
+    try:
+        d = tst - kgo
+    except:
+        print("Error: arrays have different shapes.")
+        d = kgo
     # Mask for differences larger than absolute tolerance
     maskAllDiff = (np.absolute(d) > atol)
     NallDiff = maskAllDiff.sum()
@@ -181,14 +185,8 @@ if __name__ == '__main__':
     for vname in vlst:
         kgo = read_var(args.kgo_file, vname) # KGO
         tst = read_var(args.tst_file, vname) # test
-        try:
-            summary_stats[vname] = calculate_stats(tst, kgo, 
-                                                atol=args.atol, rtol=args.rtol)
-        except:
-            summary_stats[vname].pop()
-            print(red_colour + "===== ERROR: could not compare variable "
-                  + vname + std_colour)
-            errored = True
+        summary_stats[vname] = calculate_stats(tst, kgo, 
+                                    atol=args.atol, rtol=args.rtol)
         if summary_stats[vname]['N'] > 0: errored = True
 
     # Print summary stats

--- a/driver/data/outputs/UKMO/cosp2_output.um_global.gfortran.kgo.v004.nc.md5
+++ b/driver/data/outputs/UKMO/cosp2_output.um_global.gfortran.kgo.v004.nc.md5
@@ -1,0 +1,1 @@
+71cb2284eb577bc2facec5f28520fdef  cosp2_output.um_global.gfortran.kgo.v004.nc

--- a/driver/data/outputs/UKMO/cosp2_output.um_global.ifort.kgo.v005.nc.md5
+++ b/driver/data/outputs/UKMO/cosp2_output.um_global.ifort.kgo.v005.nc.md5
@@ -1,0 +1,1 @@
+7ffad70c1e7107371c9a65b7d9c3d37e  cosp2_output.um_global.ifort.kgo.v005.nc

--- a/driver/data/outputs/UKMO/cosp2_output.um_global.ifx.kgo.v005.nc.md5
+++ b/driver/data/outputs/UKMO/cosp2_output.um_global.ifx.kgo.v005.nc.md5
@@ -1,0 +1,1 @@
+922e12f2615cdd2fbe3c70cf051e7764  cosp2_output.um_global.ifx.kgo.v005.nc

--- a/driver/data/outputs/UKMO/cosp2_output.um_global_model_levels.gfortran.kgo.v004.nc.md5
+++ b/driver/data/outputs/UKMO/cosp2_output.um_global_model_levels.gfortran.kgo.v004.nc.md5
@@ -1,0 +1,1 @@
+82d35194587672384d5a5d1ad0a84fb2  cosp2_output.um_global_model_levels.gfortran.kgo.v004.nc

--- a/driver/data/outputs/UKMO/cosp2_output_um.gfortran.kgo.v004.nc.md5
+++ b/driver/data/outputs/UKMO/cosp2_output_um.gfortran.kgo.v004.nc.md5
@@ -1,0 +1,1 @@
+886365174837f02220e17ec64b601cce  cosp2_output_um.gfortran.kgo.v004.nc

--- a/driver/data/outputs/UKMO/cosp2_output_um.ifort.kgo.v005.nc.md5
+++ b/driver/data/outputs/UKMO/cosp2_output_um.ifort.kgo.v005.nc.md5
@@ -1,0 +1,1 @@
+57bef996ced3ee9553fd5cceb20c8c21  cosp2_output_um.ifort.kgo.v005.nc

--- a/driver/data/outputs/UKMO/cosp2_output_um.ifx.kgo.v005.nc.md5
+++ b/driver/data/outputs/UKMO/cosp2_output_um.ifx.kgo.v005.nc.md5
@@ -1,0 +1,1 @@
+acca99a51056885026fb2fd9f23ca295  cosp2_output_um.ifx.kgo.v005.nc

--- a/driver/plot_test_outputs.py
+++ b/driver/plot_test_outputs.py
@@ -190,7 +190,7 @@ def plot_pcolormesh(x, y, v, d, fig_name, title=None, coastlines=False):
         ax = plt.axes(projection=ccrs.PlateCarree(central_longitude=0))
         ax.coastlines()
     h = plt.pcolormesh(x, y, v, cmap=cmap, vmax=d['vmax'])
-    if d['xticks_labels']:
+    if d['xticks_labels'] and len(d['xticks_labels']) == len(d['xticks']):
         plt.xticks(d['xticks'],d['xticks_labels'])
     else:
         plt.xticks(d['xticks'])

--- a/driver/plot_test_outputs.py
+++ b/driver/plot_test_outputs.py
@@ -194,7 +194,7 @@ def plot_pcolormesh(x, y, v, d, fig_name, title=None, coastlines=False):
         plt.xticks(d['xticks'],d['xticks_labels'])
     else:
         plt.xticks(d['xticks'])
-    if d['yticks_labels']:
+    if d['yticks_labels'] and len(d['yticks_labels']) == len(d['yticks']):
         plt.yticks(d['yticks'],d['yticks_labels'])
     else:
         plt.yticks(d['yticks'])

--- a/src/cosp_config.F90
+++ b/src/cosp_config.F90
@@ -133,11 +133,11 @@ MODULE MOD_COSP_CONFIG
     integer :: i,j
     integer,parameter :: &
          nReffLiq = 6, & ! Number of ReffLiq bins for tau/ReffLiq and LWP/ReffLiq joint-histogram
-         nReffIce = 6    ! Number of ReffIce bins for tau/ReffICE and IWP/ReffIce joint-histogram
+         nReffIce = 7    ! Number of ReffIce bins for tau/ReffICE and IWP/ReffIce joint-histogram
     real(wp),parameter,dimension(nReffLiq+1) :: &
          reffLIQ_binBounds = (/4.0e-6, 8e-6, 1.0e-5, 1.25e-5, 1.5e-5, 2.0e-5, 3.0e-5/)
     real(wp),parameter,dimension(nReffIce+1) :: &
-         reffICE_binBounds = (/5.0e-6, 1.0e-5, 2.0e-5, 3.0e-5, 4.0e-5, 5.0e-5, 6.0e-5/)
+         reffICE_binBounds = (/5.0e-6, 1.0e-5, 2.0e-5, 3.0e-5, 4.0e-5, 5.0e-5, 6.0e-5, 1.0e-2/)
     real(wp),parameter,dimension(2,nReffICE) :: &
          reffICE_binEdges = reshape(source=(/reffICE_binBounds(1),((reffICE_binBounds(k),  &
                                     l=1,2),k=2,nReffICE),reffICE_binBounds(nReffICE+1)/),  &

--- a/src/cosp_config.F90
+++ b/src/cosp_config.F90
@@ -133,11 +133,11 @@ MODULE MOD_COSP_CONFIG
     integer :: i,j
     integer,parameter :: &
          nReffLiq = 6, & ! Number of ReffLiq bins for tau/ReffLiq and LWP/ReffLiq joint-histogram
-         nReffIce = 7    ! Number of ReffIce bins for tau/ReffICE and IWP/ReffIce joint-histogram
+         nReffIce = 6    ! Number of ReffIce bins for tau/ReffICE and IWP/ReffIce joint-histogram
     real(wp),parameter,dimension(nReffLiq+1) :: &
          reffLIQ_binBounds = (/4.0e-6, 8e-6, 1.0e-5, 1.25e-5, 1.5e-5, 2.0e-5, 3.0e-5/)
     real(wp),parameter,dimension(nReffIce+1) :: &
-         reffICE_binBounds = (/5.0e-6, 1.0e-5, 2.0e-5, 3.0e-5, 4.0e-5, 5.0e-5, 6.0e-5, 1.0e-2/)
+         reffICE_binBounds = (/5.0e-6, 1.0e-5, 2.0e-5, 3.0e-5, 4.0e-5, 5.0e-5, 6.0e-5/)
     real(wp),parameter,dimension(2,nReffICE) :: &
          reffICE_binEdges = reshape(source=(/reffICE_binBounds(1),((reffICE_binBounds(k),  &
                                     l=1,2),k=2,nReffICE),reffICE_binBounds(nReffICE+1)/),  &


### PR DESCRIPTION
When there is failure in the comparison of the outputs against the KGO **and** the generation of the plots also fails (e.g. due to a change in the dimensions of one of the outputs like in #110 ), then the tgz files with the new outputs are not created. This fixes this by trapping the error in compare_to_kgo.py. The CI workflows are slightly modified: all the comparisons against the KGOs are run even after failure in previous comparisons. I'm also adding the md5 sums of the KGOs for #110 