### PR TITLE
Fix masked data

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -160,7 +160,6 @@ jobs:
         KGO=data/outputs/UKMO/cosp2_output.um_global.${F90_SHORT_NAME}.kgo.$KGO_VERSION.nc
         TST=data/outputs/UKMO/cosp2_output.um_global.nc
         python compare_to_kgo.py ${KGO} ${TST} --atol=${ATOL} --rtol=${RTOL}
-        exit 1
     # 3. UM global snapshot. Diagnostics on model levels.
     - name: UM global on model levels against known good output (KGO)
       if: always()

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -160,6 +160,7 @@ jobs:
         KGO=data/outputs/UKMO/cosp2_output.um_global.${F90_SHORT_NAME}.kgo.$KGO_VERSION.nc
         TST=data/outputs/UKMO/cosp2_output.um_global.nc
         python compare_to_kgo.py ${KGO} ${TST} --atol=${ATOL} --rtol=${RTOL}
+        exit 1
     # 3. UM global snapshot. Diagnostics on model levels.
     - name: UM global on model levels against known good output (KGO)
       if: always()

--- a/driver/plot_test_outputs.py
+++ b/driver/plot_test_outputs.py
@@ -244,9 +244,9 @@ def read_var_to_masked_array(fname, vname, fill_value, Nlat_lon = None):
         long_name: long name attribute.
     """
     f_id = netCDF4.Dataset(fname, 'r')
-    x = np.ma.masked_equal(f_id.variables[vname][:], fill_value)
-    lon = np.ma.masked_equal(f_id.variables['longitude'][:], fill_value)
-    lat = np.ma.masked_equal(f_id.variables['latitude'][:], fill_value)
+    x = np.ma.masked_values(f_id.variables[vname][:], fill_value)
+    lon = np.ma.masked_values(f_id.variables['longitude'][:], fill_value)
+    lat = np.ma.masked_values(f_id.variables['latitude'][:], fill_value)
     units = f_id.variables[vname].getncattr('units')
     long_name = f_id.variables[vname].getncattr('long_name')
     f_id.close()


### PR DESCRIPTION
This PR fixes the issue #121. This error seems to appear when numpy v2 is used. The creation of masked arrays using `masked_values` seems to be a more robust approach as it works for numpy 1.26.4, tested locally, and for numpy 2.3.0 used in the CI workflow. Examples of plots produced by the CI workflow with the fix applied:
![cosp2_output um_global nc albisccp](https://github.com/user-attachments/assets/eae3746d-402a-4f73-b030-f868e41c9980)
![cosp2_output um_global nc cfadDbze94](https://github.com/user-attachments/assets/7c909cf2-0e1c-45a3-82f9-1c7c078bf510)
![cosp2_output um_global nc clatlid](https://github.com/user-attachments/assets/7e7c630d-d280-43a9-a502-6c95d806201d)


