### PR TITLE
Centralise download of large files (inputs and KGOs)

### DIFF
--- a/.github/workflows/containerized-ci.yml
+++ b/.github/workflows/containerized-ci.yml
@@ -12,13 +12,9 @@ jobs:
         # Flags and KGOs for Intel Fortran Compiler Classic
         - compiler: ifort
           fcflags: -m64 -g -traceback -heap-arrays -assume realloc_lhs -extend-source 132 -check bounds,uninit,pointers,stack -stand f08
-          gdkgo1: https://docs.google.com/uc?export=download&id=1R6uvtWno-bhdgxACCwdcaRNXs9l5_G4w
-          gdkgo2: https://docs.google.com/uc?export=download&id=1bVU1_dx6hXcV_fHX2cLUn-D03T-Hij8z
         # Flags and KGOs for Intel Fortran Compiler
         - compiler: ifx
           fcflags: -debug -traceback -O0 -heap-arrays -assume realloc_lhs -extend-source 132 -stand f08
-          gdkgo1: https://docs.google.com/uc?export=download&id=1CLPJ1ikAcGBEiZ3WAGqL-zpaPIgC__po
-          gdkgo2: https://docs.google.com/uc?export=download&id=1JOrLFbt0BYgpD0h6A3tsoRD4iTJ4jDvZ
         # Set container images
         - compiler: ifort
           image: ghcr.io/earth-system-radiation/rte-rrtmgp-ci:oneapi
@@ -41,8 +37,6 @@ jobs:
       ATOL: 0.0
       RTOL: 0.0
       KGO_VERSION: ${{ matrix.kgo_version }}
-      GDKGO1: ${{ matrix.gdkgo1 }}
-      GDKGO2: ${{ matrix.gdkgo2 }}
     steps:
     #
     # Checks-out repository under $GITHUB_WORKSPACE
@@ -71,30 +65,11 @@ jobs:
         cd build
         make -j driver
     # Retrieve and expand large data files
-    - name: Retrieve input files
+    - name: Retrieve input files and KGOs
       run: |
-        GDFILE='https://docs.google.com/uc?export=download&id=17eK4_DVEvFOE9Uf6siXJDpWZJKT1aqkU'
-        OUTPATH=driver/data/inputs/UKMO/cosp_input.um_global.nc.gz
-        curl -sSfL -o $OUTPATH $GDFILE
-        gunzip ${OUTPATH}
-        cd driver/data/inputs/UKMO
-        md5sum -c cosp_input.um_global.nc.md5
-    - name: Retrieve KGOs for basic test
-      run: |
+        cd driver
+        . download_test_data.sh ${F90}
         cd ${GITHUB_WORKSPACE}
-        OUTPATH=driver/data/outputs/UKMO/cosp2_output_um.$F90.kgo.$KGO_VERSION.nc.gz
-        curl -sSfL -o $OUTPATH $GDKGO1
-        gunzip ${OUTPATH}
-        cd driver/data/outputs/UKMO
-        # md5sum -c cosp2_output_um.${F90}.kgo.$KGO_VERSION.nc.md5
-    - name: Retrieve KGOs for global test
-      run: |
-        cd ${GITHUB_WORKSPACE}
-        OUTPATH=driver/data/outputs/UKMO/cosp2_output.um_global.${F90}.kgo.$KGO_VERSION.nc.gz
-        curl -sSfL -o $OUTPATH $GDKGO2
-        gunzip ${OUTPATH}
-        cd driver/data/outputs/UKMO
-        # md5sum -c cosp2_output.um_global.${F90}.kgo.$KGO_VERSION.nc.md5
     ###############################################################################
     # Run COSP2 tests. Basic test and UM global snapshot
     ###############################################################################

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -92,39 +92,11 @@ jobs:
         cd build
         make -j driver
     # Retrieve and expand large data files
-    - name: Retrieve input files
+    - name: Retrieve input files and KGOs
       run: |
-        GDFILE='https://docs.google.com/uc?export=download&id=17eK4_DVEvFOE9Uf6siXJDpWZJKT1aqkU'
-        OUTPATH=driver/data/inputs/UKMO/cosp_input.um_global.nc.gz
-        curl -sSfL -o $OUTPATH $GDFILE
-        gunzip ${OUTPATH}
-        cd driver/data/inputs/UKMO
-        md5sum -c cosp_input.um_global.nc.md5
-    - name: Retrieve KGOs for basic test
-      run: |
+        cd driver
+        . download_test_data.sh
         cd ${GITHUB_WORKSPACE}
-        OUTPATH=driver/data/outputs/UKMO/cosp2_output_um.${F90_SHORT_NAME}.kgo.$KGO_VERSION.nc.gz
-        curl -sSfL -o $OUTPATH $GDKGO1
-        gunzip ${OUTPATH}
-        cd driver/data/outputs/UKMO
-        md5sum -c cosp2_output_um.${F90_SHORT_NAME}.kgo.$KGO_VERSION.nc.md5
-    - name: Retrieve KGOs for global test
-      run: |
-        cd ${GITHUB_WORKSPACE}
-        OUTPATH=driver/data/outputs/UKMO/cosp2_output.um_global.${F90_SHORT_NAME}.kgo.$KGO_VERSION.nc.gz
-        curl -sSfL -o $OUTPATH $GDKGO2
-        gunzip ${OUTPATH}
-        cd driver/data/outputs/UKMO
-        md5sum -c cosp2_output.um_global.${F90_SHORT_NAME}.kgo.$KGO_VERSION.nc.md5
-        cd ${GITHUB_WORKSPACE}
-    - name: Retrieve KGOs for global test with outputs on model levels
-      run: |
-        cd ${GITHUB_WORKSPACE}
-        OUTPATH=driver/data/outputs/UKMO/cosp2_output.um_global_model_levels.${F90_SHORT_NAME}.kgo.$KGO_VERSION.nc.gz
-        curl -sSfL -o $OUTPATH $GDKGO3
-        gunzip ${OUTPATH}
-        cd driver/data/outputs/UKMO
-        md5sum -c cosp2_output.um_global_model_levels.${F90_SHORT_NAME}.kgo.$KGO_VERSION.nc.md5
     ###############################################################################
     # Run COSP2 tests. We could run both tests in one step, but
     # doing it this way the output is easier to interpret.

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -89,7 +89,7 @@ jobs:
     - name: Retrieve input files and KGOs
       run: |
         cd driver
-        . download_test_data.sh
+        . download_test_data.sh ${F90}
         cd ${GITHUB_WORKSPACE}
     ###############################################################################
     # Run COSP2 tests. We could run both tests in one step, but

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -160,6 +160,7 @@ jobs:
         KGO=data/outputs/UKMO/cosp2_output.um_global.${F90_SHORT_NAME}.kgo.$KGO_VERSION.nc
         TST=data/outputs/UKMO/cosp2_output.um_global.nc
         python compare_to_kgo.py ${KGO} ${TST} --atol=${ATOL} --rtol=${RTOL}
+        exit 1
     # 3. UM global snapshot. Diagnostics on model levels.
     - name: UM global on model levels against known good output (KGO)
       if: always()

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -33,11 +33,11 @@ jobs:
   # This workflow contains a single job called "ci_gfortran"
   ci_gfortran:
     # The type of runner that the job will run on
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
-        compiler: [gfortran-12]
+        compiler: [gfortran-10, gfortran-11, gfortran-12]
         python-version: [3.11]
         include:
           - compiler_short_name: gfortran
@@ -160,7 +160,6 @@ jobs:
         KGO=data/outputs/UKMO/cosp2_output.um_global.${F90_SHORT_NAME}.kgo.$KGO_VERSION.nc
         TST=data/outputs/UKMO/cosp2_output.um_global.nc
         python compare_to_kgo.py ${KGO} ${TST} --atol=${ATOL} --rtol=${RTOL}
-        exit 1
     # 3. UM global snapshot. Diagnostics on model levels.
     - name: UM global on model levels against known good output (KGO)
       if: always()

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -33,11 +33,11 @@ jobs:
   # This workflow contains a single job called "ci_gfortran"
   ci_gfortran:
     # The type of runner that the job will run on
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
-        compiler: [gfortran-10, gfortran-11, gfortran-12]
+        compiler: [gfortran-12]
         python-version: [3.11]
         include:
           - compiler_short_name: gfortran

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -53,12 +53,6 @@ jobs:
       ATOL: 0.0
       RTOL: 0.0
       KGO_VERSION: ${{ matrix.kgo_version }}
-      # KGO1 is cosp2_output_um.gfortran.kgo.vNNN.nc.gz
-      GDKGO1: https://docs.google.com/uc?export=download&id=1kC9RViPBdAsGcOivpYXxs3hHJ11Kv8IN
-      # KGO2 is cosp2_output.um_global.gfortran.kgo.vNNN.nc.gz
-      GDKGO2: https://docs.google.com/uc?export=download&id=1X_oOzvY2lf-kyAR-D1E6JfuefkGg1idn
-      # KGO3 is cosp2_output.um_global_model_levels.gfortran.kgo.vNNN.nc.gz
-      GDKGO3: https://docs.google.com/uc?export=download&id=1c14qBf9VwYJWYVGCu-Cw35F-qqHx0mSg
       F90_SHORT_NAME: ${{ matrix.compiler_short_name }}
     # Sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -89,7 +89,7 @@ jobs:
     - name: Retrieve input files and KGOs
       run: |
         cd driver
-        . download_test_data.sh ${F90}
+        . download_test_data.sh ${F90_SHORT_NAME}
         cd ${GITHUB_WORKSPACE}
     ###############################################################################
     # Run COSP2 tests. We could run both tests in one step, but

--- a/driver/download_test_data.sh
+++ b/driver/download_test_data.sh
@@ -1,16 +1,11 @@
 #/bin/bash
 
-if [[ -n ${KGO_VERSION} ]] ; then
-    echo "KGO_VERSION=$KGO_VERSION"
-else
-    export KGO_VERSION=v003
-    echo "set KGO_VERSION=$KGO_VERSION"
-fi
+KGO_VERSION=v004
+echo "KGO_VERSION=$KGO_VERSION"
 
-
-kgo_links=( "https://docs.google.com/uc?export=download&id=1oQBJGFg0F8k-LhRGsCYn-qWzmMMVfQ6K" \
-            "https://docs.google.com/uc?export=download&id=1b7qwJWqDzoZGcIP0qyUprTV_LErCGpT6" \
-            "https://docs.google.com/uc?export=download&id=1NvTo3bYaGpz-FUpZ4jta_kRzA04xTCsn" )
+kgo_links=( "https://docs.google.com/uc?export=download&id=1kC9RViPBdAsGcOivpYXxs3hHJ11Kv8IN" \
+            "https://docs.google.com/uc?export=download&id=1X_oOzvY2lf-kyAR-D1E6JfuefkGg1idn" \
+            "https://docs.google.com/uc?export=download&id=1c14qBf9VwYJWYVGCu-Cw35F-qqHx0mSg" )
 
 out_type=( "cosp2_output_um.gfortran.kgo" \
            "cosp2_output.um_global.gfortran.kgo" \
@@ -25,16 +20,12 @@ gunzip -f ${OUTPATH}
 cd data/inputs/UKMO
 md5sum -c cosp_input.um_global.nc.md5
 
-if [[ ${KGO_VERSION} == "v002" ]] ; then
-  for i in ${!kgo_links[@]}; do
-    cd ${DRIVER_DIR}
-    GDFILE=${kgo_links[$i]}
-    OUTPATH=data/outputs/UKMO/${out_type[$i]}.$KGO_VERSION.nc.gz
-    wget --no-check-certificate $GDFILE -O $OUTPATH
-    gunzip -f ${OUTPATH}
-    cd data/outputs/UKMO
-    md5sum -c ${out_type[$i]}.$KGO_VERSION.nc.md5
-  done
-else
-  echo "wrong KGO_VERSION supplied, try 'export KGO_VERSION=v002'"
-fi
+for i in ${!kgo_links[@]}; do
+  cd ${DRIVER_DIR}
+  GDFILE=${kgo_links[$i]}
+  OUTPATH=data/outputs/UKMO/${out_type[$i]}.$KGO_VERSION.nc.gz
+  wget --no-check-certificate $GDFILE -O $OUTPATH
+  gunzip -f ${OUTPATH}
+  cd data/outputs/UKMO
+  md5sum -c ${out_type[$i]}.$KGO_VERSION.nc.md5
+done

--- a/driver/download_test_data.sh
+++ b/driver/download_test_data.sh
@@ -9,25 +9,25 @@ case $COMPILER in
     kgo_links=( "https://docs.google.com/uc?export=download&id=1kC9RViPBdAsGcOivpYXxs3hHJ11Kv8IN" \
                 "https://docs.google.com/uc?export=download&id=1X_oOzvY2lf-kyAR-D1E6JfuefkGg1idn" \
                 "https://docs.google.com/uc?export=download&id=1c14qBf9VwYJWYVGCu-Cw35F-qqHx0mSg" )
-    out_type=( "cosp2_output_um.gfortran.kgo" \
-               "cosp2_output.um_global.gfortran.kgo" \
-               "cosp2_output.um_global_model_levels.gfortran.kgo" )
+    out_type=( "cosp2_output_um.${COMPILER}.kgo" \
+               "cosp2_output.um_global.${COMPILER}.kgo" \
+               "cosp2_output.um_global_model_levels.${COMPILER}.kgo" )
     ;;
 
    "ifort")
     KGO_VERSION=v005
     kgo_links=( "https://docs.google.com/uc?export=download&id=1R6uvtWno-bhdgxACCwdcaRNXs9l5_G4w" \
                 "https://docs.google.com/uc?export=download&id=1bVU1_dx6hXcV_fHX2cLUn-D03T-Hij8z" )
-    out_type=( "cosp2_output_um.ifort.kgo" \
-               "cosp2_output.um_global.ifort.kgo" )
+    out_type=( "cosp2_output_um.${COMPILER}.kgo" \
+               "cosp2_output.um_global.${COMPILER}.kgo" )
     ;;
 
    "ifx")
     KGO_VERSION=v005
     kgo_links=( "https://docs.google.com/uc?export=download&id=1CLPJ1ikAcGBEiZ3WAGqL-zpaPIgC__po" \
                 "https://docs.google.com/uc?export=download&id=1JOrLFbt0BYgpD0h6A3tsoRD4iTJ4jDvZ" )
-    out_type=( "cosp2_output_um.ifort.kgo" \
-               "cosp2_output.um_global.ifort.kgo" )
+    out_type=( "cosp2_output_um.${COMPILER}.kgo" \
+               "cosp2_output.um_global.${COMPILER}.kgo" )
     ;;
 
   *)

--- a/driver/download_test_data.sh
+++ b/driver/download_test_data.sh
@@ -31,7 +31,8 @@ case $COMPILER in
     ;;
 
   *)
-    echo -n "Invalid compiler"
+    echo "ERROR: Invalid compiler"
+    exit 1
     ;;
 esac
 

--- a/driver/download_test_data.sh
+++ b/driver/download_test_data.sh
@@ -1,15 +1,41 @@
 #/bin/bash
 
-KGO_VERSION=v004
+COMPILER=$1
+
+case $COMPILER in
+
+  "gfortran")
+    KGO_VERSION=v004
+    kgo_links=( "https://docs.google.com/uc?export=download&id=1kC9RViPBdAsGcOivpYXxs3hHJ11Kv8IN" \
+                "https://docs.google.com/uc?export=download&id=1X_oOzvY2lf-kyAR-D1E6JfuefkGg1idn" \
+                "https://docs.google.com/uc?export=download&id=1c14qBf9VwYJWYVGCu-Cw35F-qqHx0mSg" )
+    out_type=( "cosp2_output_um.gfortran.kgo" \
+               "cosp2_output.um_global.gfortran.kgo" \
+               "cosp2_output.um_global_model_levels.gfortran.kgo" )
+    ;;
+
+   "ifort")
+    KGO_VERSION=v005
+    kgo_links=( "https://docs.google.com/uc?export=download&id=1R6uvtWno-bhdgxACCwdcaRNXs9l5_G4w" \
+                "https://docs.google.com/uc?export=download&id=1bVU1_dx6hXcV_fHX2cLUn-D03T-Hij8z" )
+    out_type=( "cosp2_output_um.ifort.kgo" \
+               "cosp2_output.um_global.ifort.kgo" )
+    ;;
+
+   "ifx")
+    KGO_VERSION=v005
+    kgo_links=( "https://docs.google.com/uc?export=download&id=1CLPJ1ikAcGBEiZ3WAGqL-zpaPIgC__po" \
+                "https://docs.google.com/uc?export=download&id=1JOrLFbt0BYgpD0h6A3tsoRD4iTJ4jDvZ" )
+    out_type=( "cosp2_output_um.ifort.kgo" \
+               "cosp2_output.um_global.ifort.kgo" )
+    ;;
+
+  *)
+    echo -n "Invalid compiler"
+    ;;
+esac
+
 echo "KGO_VERSION=$KGO_VERSION"
-
-kgo_links=( "https://docs.google.com/uc?export=download&id=1kC9RViPBdAsGcOivpYXxs3hHJ11Kv8IN" \
-            "https://docs.google.com/uc?export=download&id=1X_oOzvY2lf-kyAR-D1E6JfuefkGg1idn" \
-            "https://docs.google.com/uc?export=download&id=1c14qBf9VwYJWYVGCu-Cw35F-qqHx0mSg" )
-
-out_type=( "cosp2_output_um.gfortran.kgo" \
-           "cosp2_output.um_global.gfortran.kgo" \
-           "cosp2_output.um_global_model_levels.gfortran.kgo" )
 
 # Input: global UM
 DRIVER_DIR=${PWD}

--- a/driver/download_test_data.sh
+++ b/driver/download_test_data.sh
@@ -50,7 +50,7 @@ for i in ${!kgo_links[@]}; do
   cd ${DRIVER_DIR}
   GDFILE=${kgo_links[$i]}
   OUTPATH=data/outputs/UKMO/${out_type[$i]}.$KGO_VERSION.nc.gz
-  wget --no-check-certificate $GDFILE -O $OUTPATH
+  curl -sSfL -o $OUTPATH $GDFILE
   gunzip -f ${OUTPATH}
   cd data/outputs/UKMO
   md5sum -c ${out_type[$i]}.$KGO_VERSION.nc.md5

--- a/driver/download_test_data.sh
+++ b/driver/download_test_data.sh
@@ -42,7 +42,7 @@ echo "KGO_VERSION=$KGO_VERSION"
 DRIVER_DIR=${PWD}
 GDFILE='https://docs.google.com/uc?export=download&id=17eK4_DVEvFOE9Uf6siXJDpWZJKT1aqkU'
 OUTPATH=data/inputs/UKMO/cosp_input.um_global.nc.gz
-wget --no-check-certificate $GDFILE -O $OUTPATH
+curl -sSfL -o $OUTPATH $GDFILE
 gunzip -f ${OUTPATH}
 cd data/inputs/UKMO
 md5sum -c cosp_input.um_global.nc.md5

--- a/driver/plot_test_outputs.py
+++ b/driver/plot_test_outputs.py
@@ -27,6 +27,7 @@
 
 import netCDF4,argparse,sys
 import numpy as np
+import matplotlib
 import matplotlib.pyplot as plt
 import cartopy.crs as ccrs
 import os
@@ -378,4 +379,6 @@ if __name__ == '__main__':
     produce_cosp_summary_plots(args.tst_file, vars2D, args.out_dir,
                                Nlat_lon=(args.Nlat, args.Nlon))
 
+    print(np.__version__)
+    print(matplotlib.__version__)
     print("===== Summary plots produced =====")

--- a/driver/plot_test_outputs.py
+++ b/driver/plot_test_outputs.py
@@ -27,7 +27,6 @@
 
 import netCDF4,argparse,sys
 import numpy as np
-import matplotlib
 import matplotlib.pyplot as plt
 import cartopy.crs as ccrs
 import os
@@ -245,11 +244,7 @@ def read_var_to_masked_array(fname, vname, fill_value, Nlat_lon = None):
         long_name: long name attribute.
     """
     f_id = netCDF4.Dataset(fname, 'r')
-    xx = f_id.variables[vname][:]
-    print("type(xx):", type(xx))
-    print("xx.dtype:", xx.dtype)
-    print("type(fill_value):", type(fill_value))
-    x = np.ma.masked_values(f_id.variables[vname][:], fill_value)
+    x = np.ma.masked_equal(f_id.variables[vname][:], fill_value)
     lon = np.ma.masked_equal(f_id.variables['longitude'][:], fill_value)
     lat = np.ma.masked_equal(f_id.variables['latitude'][:], fill_value)
     units = f_id.variables[vname].getncattr('units')
@@ -285,7 +280,6 @@ def produce_cosp_summary_plots(fname, variables, output_dir, Nlat_lon = None):
         fig_name = os.path.join(output_dir, ".".join([os.path.basename(fname), vname, 'png']))
         coastlines = False
         if vd['plot_type'] == 'map': coastlines = True
-        print(z[:,20])
         plot_pcolormesh(x, y, z, pkw, fig_name, title=title, coastlines=coastlines)
 
 def variable2D_metadata(var_list, fname):
@@ -368,7 +362,6 @@ if __name__ == '__main__':
                      'clcalipsoopacity','clgrLidar532','clatlid','clcalipso2',
                      'lidarBetaMol532gr','lidarBetaMol532','lidarBetaMol355']
     v2D_all_names = v2D_maps_names + v2D_hists_names + v2D_zcs_names
-    v2D_all_names = ['albisccp']
     # Plots for these variables are not yet developed
     # atb532_perp(lev, cosp_scol, loc);
     # atb532(lev, cosp_scol, loc);
@@ -385,6 +378,4 @@ if __name__ == '__main__':
     produce_cosp_summary_plots(args.tst_file, vars2D, args.out_dir,
                                Nlat_lon=(args.Nlat, args.Nlon))
 
-    print(np.__version__)
-    print(matplotlib.__version__)
     print("===== Summary plots produced =====")

--- a/driver/plot_test_outputs.py
+++ b/driver/plot_test_outputs.py
@@ -281,6 +281,7 @@ def produce_cosp_summary_plots(fname, variables, output_dir, Nlat_lon = None):
         fig_name = os.path.join(output_dir, ".".join([os.path.basename(fname), vname, 'png']))
         coastlines = False
         if vd['plot_type'] == 'map': coastlines = True
+        print(z[:,20])
         plot_pcolormesh(x, y, z, pkw, fig_name, title=title, coastlines=coastlines)
 
 def variable2D_metadata(var_list, fname):
@@ -363,6 +364,7 @@ if __name__ == '__main__':
                      'clcalipsoopacity','clgrLidar532','clatlid','clcalipso2',
                      'lidarBetaMol532gr','lidarBetaMol532','lidarBetaMol355']
     v2D_all_names = v2D_maps_names + v2D_hists_names + v2D_zcs_names
+    v2D_all_names = ['albisccp']
     # Plots for these variables are not yet developed
     # atb532_perp(lev, cosp_scol, loc);
     # atb532(lev, cosp_scol, loc);

--- a/driver/plot_test_outputs.py
+++ b/driver/plot_test_outputs.py
@@ -249,7 +249,7 @@ def read_var_to_masked_array(fname, vname, fill_value, Nlat_lon = None):
     print("type(xx):", type(xx))
     print("xx.dtype:", xx.dtype)
     print("type(fill_value):", type(fill_value))
-    x = np.ma.masked_equal(f_id.variables[vname][:], fill_value)
+    x = np.ma.masked_values(f_id.variables[vname][:], fill_value)
     lon = np.ma.masked_equal(f_id.variables['longitude'][:], fill_value)
     lat = np.ma.masked_equal(f_id.variables['latitude'][:], fill_value)
     units = f_id.variables[vname].getncattr('units')

--- a/driver/plot_test_outputs.py
+++ b/driver/plot_test_outputs.py
@@ -245,6 +245,10 @@ def read_var_to_masked_array(fname, vname, fill_value, Nlat_lon = None):
         long_name: long name attribute.
     """
     f_id = netCDF4.Dataset(fname, 'r')
+    xx = f_id.variables[vname][:]
+    print("type(xx):", type(xx))
+    print("xx.dtype:", xx.dtype)
+    print("type(fill_value):", type(fill_value))
     x = np.ma.masked_equal(f_id.variables[vname][:], fill_value)
     lon = np.ma.masked_equal(f_id.variables['longitude'][:], fill_value)
     lat = np.ma.masked_equal(f_id.variables['latitude'][:], fill_value)


### PR DESCRIPTION
This addresses #119. We have links to the large files in GDrive in two places: CI workflows, and the script `download_test_data.sh`. This is error prone because when KGOs change it's easy to forget to update the script. This PR centralises the links in the script, which is then called from the CI workflows. From now on, if KGOs change only `download_test_data.sh` needs to be updated.