### PR TITLE
Allocate MODIS mask indices and add missing MODIS histograms to standard variable checks

### DIFF
--- a/src/cosp.F90
+++ b/src/cosp.F90
@@ -1739,6 +1739,14 @@ CONTAINS
                 cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure_Liq(ij+int(modisIN%notSunlit(:))-1, :, :) = R_UNDEF
              if (associated(cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure_Ice))      &
                 cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure_Ice(ij+int(modisIN%notSunlit(:))-1, :, :) = R_UNDEF
+             if (associated(cospOUT%modis_LWP_vs_ReffLIQ))      &
+                cospOUT%modis_LWP_vs_ReffLIQ(ij+int(modisIN%notSunlit(:))-1, :, :) = R_UNDEF
+             if (associated(cospOUT%modis_IWP_vs_ReffICE))      &
+                cospOUT%modis_IWP_vs_ReffICE(ij+int(modisIN%notSunlit(:))-1, :, :) = R_UNDEF
+             if (associated(cospOUT%modis_Optical_Thickness_vs_ReffIce))      &
+                cospOUT%modis_Optical_Thickness_vs_ReffIce(ij+int(modisIN%notSunlit(:))-1, :, :) = R_UNDEF
+             if (associated(cospOUT%modis_Optical_Thickness_vs_ReffLiq))      &
+                cospOUT%modis_Optical_Thickness_vs_ReffLiq(ij+int(modisIN%notSunlit(:))-1, :, :) = R_UNDEF
           end if
        else
           ! It's nightime everywhere - everything is undefined
@@ -1782,6 +1790,14 @@ CONTAINS
              cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure_Liq(ij+int(modisIN%notSunlit(:))-1, :, :) = R_UNDEF
           if (associated(cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure_Ice))      &
              cospOUT%modis_Optical_Thickness_vs_Cloud_Top_Pressure_Ice(ij+int(modisIN%notSunlit(:))-1, :, :) = R_UNDEF
+          if (associated(cospOUT%modis_LWP_vs_ReffLIQ))      &
+             cospOUT%modis_LWP_vs_ReffLIQ(ij+int(modisIN%notSunlit(:))-1, :, :) = R_UNDEF
+          if (associated(cospOUT%modis_IWP_vs_ReffICE))      &
+             cospOUT%modis_IWP_vs_ReffICE(ij+int(modisIN%notSunlit(:))-1, :, :) = R_UNDEF
+          if (associated(cospOUT%modis_Optical_Thickness_vs_ReffIce))      &
+             cospOUT%modis_Optical_Thickness_vs_ReffIce(ij+int(modisIN%notSunlit(:))-1, :, :) = R_UNDEF
+          if (associated(cospOUT%modis_Optical_Thickness_vs_ReffLiq))      &
+             cospOUT%modis_Optical_Thickness_vs_ReffLiq(ij+int(modisIN%notSunlit(:))-1, :, :) = R_UNDEF
        endif
        ! Free up memory (if necessary)
        if (allocated(modisRetrievedTau))               deallocate(modisRetrievedTau)

--- a/src/simulator/cosp_modis_interface.F90
+++ b/src/simulator/cosp_modis_interface.F90
@@ -167,6 +167,7 @@ contains
          if (allocated(CSCAL_SWATH_MASK)) then
             allocate(MODIS_CSCAL_SWATH_MASK(Npoints))
             MODIS_CSCAL_SWATH_MASK = (.not. (MODIS_SWATH_MASK .and. CSCAL_SWATH_MASK)) ! Gridcells not seen by both MODIS and CSCAL should be set to zero
+            if (.not. allocated(MODIS_CSCAL_MASK_INDICES)) allocate(MODIS_CSCAL_MASK_INDICES(count(MODIS_CSCAL_SWATH_MASK)))
             MODIS_CSCAL_MASK_INDICES = pack((/ (i, i = 1, Npoints ) /),mask = MODIS_CSCAL_SWATH_MASK)
          end if
       else


### PR DESCRIPTION
Four MODIS histogram variables (below) were missing from checks that assign nans when gridcells are not sunlit and thus unobserved. This PR adds those checks and also explicitly allocates "MODIS_CSCAL_MASK_INDICES", which is used to track which gridcells should be mask when swathing is enabled.

modis_LWP_vs_ReffLIQ
modis_IWP_vs_ReffICE
modis_Optical_Thickness_vs_ReffIce
modis_Optical_Thickness_vs_ReffLiq

The kgo changes result from new nan'd regions in the MODIS variables that were previous holding values when they should have been masked.