### PR TITLE
Add guards to assignment of RTTOV trace gas profiles when ppmv units are used

### DIFF
--- a/src/simulator/rttov/cosp_rttov_v13.F90
+++ b/src/simulator/rttov/cosp_rttov_v13.F90
@@ -754,17 +754,6 @@ contains
           else
              inst_profiles(j)%skin%surftype  = surftype_seaice
           end if
-          
-          ! land-sea mask (lsmask) indicates proportion of land in grid (not in CESM implementation! just a binary mask there)
-!          if (rttovIN%lsmask(i) < 0.5) then
-!            inst_profiles(j)%skin%surftype  = surftype_sea
-!          else
-!            inst_profiles(j)%skin%surftype  = surftype_land
-!          endif
-          ! sea-ice fraction
-!          if (rttovIN%icefrac(i) >= 0.5) then
-!            inst_profiles(j)%skin%surftype  = surftype_seaice
-!          endif
 
           ! dar: hard-coded to 1 (=ocean water) in rttov 9 int
           inst_profiles(j)%skin%watertype = 1
@@ -781,12 +770,12 @@ contains
             ! Convert to ppmv over dry air
             inst_profiles(j)%s2m%q     = (inst_profiles(j)%s2m%q / (1.0 - inst_profiles(j)%s2m%q)) * mdry / mH2O * 1.e6
             inst_profiles(j)%q(:)      = (inst_profiles(j)%q(:) / (1.0 - inst_profiles(j)%q(:))) * mdry / mH2O * 1.e6
-            inst_profiles(j)%o3(:)     = inst_profiles(j)%o3(:) * mdry / mO3 * 1.e6
-            inst_profiles(j)%co2(:)    = inst_profiles(j)%co2(:) * mdry / mCO2 * 1.e6
-            inst_profiles(j)%ch4(:)    = inst_profiles(j)%ch4(:) * mdry / mCH4 * 1.e6
-            inst_profiles(j)%n2o(:)    = inst_profiles(j)%n2o(:) * mdry / mN2O * 1.e6
-            inst_profiles(j)%co(:)     = inst_profiles(j)%co(:) * mdry / mCO * 1.e6
-            inst_profiles(j)%so2(:)    = inst_profiles(j)%so2(:) * mdry / mSO2 * 1.e6
+            if (Ldo_o3)  inst_profiles(j)%o3(:)     = inst_profiles(j)%o3(:) * mdry / mO3 * 1.e6
+            if (Ldo_co2) inst_profiles(j)%co2(:)    = inst_profiles(j)%co2(:) * mdry / mCO2 * 1.e6
+            if (Ldo_ch4) inst_profiles(j)%ch4(:)    = inst_profiles(j)%ch4(:) * mdry / mCH4 * 1.e6
+            if (Ldo_n2o) inst_profiles(j)%n2o(:)    = inst_profiles(j)%n2o(:) * mdry / mN2O * 1.e6
+            if (Ldo_co)  inst_profiles(j)%co(:)     = inst_profiles(j)%co(:) * mdry / mCO * 1.e6
+            if (Ldo_so2) inst_profiles(j)%so2(:)    = inst_profiles(j)%so2(:) * mdry / mSO2 * 1.e6
             inst_profiles(j)%gas_units  =  0
           else
             inst_profiles(j)%gas_units  =  inst_gas_units


### PR DESCRIPTION
src/simulator/rttov/cosp_rttov_v13.F90 assigns trace gas mixing ratios to the RTTOV atmospheric profile object. Because not all trace gases are used for all simulations, logicals are used to guard against assigning garbage data to the profile object. These guards were missing when trace gas units of ppmv were used, which results in a runtime error in CESM when debug settings are turned on (thank you @cacraigucar for catching this).

This PR adds those guards and removes a block of commented code. No answers are changed and all tests pass.

Also, please create a new tag when this PR is merged so that it can be immediately brought into CESM3 (merge hopefully coming very soon!).